### PR TITLE
Add explicit dependency on activemodel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     web-console (1.0.0)
+      activemodel (~> 4.0.0)
       rails (~> 4.0.0)
 
 GEM
@@ -36,7 +37,8 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     arel (4.0.0)
-    atomic (1.1.13)
+    atomic (1.1.14)
+    atomic (1.1.14-java)
     builder (3.1.4)
     coderay (1.0.9)
     daemons (1.1.9)
@@ -51,7 +53,7 @@ GEM
       treetop (~> 1.4.8)
     metaclass (0.0.1)
     method_source (0.8.2)
-    mime-types (1.24)
+    mime-types (1.25)
     minitest (4.7.5)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
@@ -111,7 +113,9 @@ GEM
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
     thor (0.18.1)
-    thread_safe (0.1.2)
+    thread_safe (0.1.3)
+      atomic
+    thread_safe (0.1.3-java)
       atomic
     tilt (1.4.1)
     treetop (1.4.15)

--- a/app/models/web_console/console_session.rb
+++ b/app/models/web_console/console_session.rb
@@ -1,3 +1,5 @@
+require 'active_model'
+
 module WebConsole
   # Manage and persist (in memory) WebConsole::Slave instances.
   class ConsoleSession

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 4.0.0"
+  s.add_dependency "activemodel", "~> 4.0.0"
 end


### PR DESCRIPTION
So that it works with Rails applications created with -O option.

Fixes issue #3
