### PR TITLE
Break rails dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,8 @@ PATH
   specs:
     web-console (1.0.0)
       activemodel (~> 4.0.0)
-      rails (~> 4.0.0)
+      railties (~> 4.0.0)
+      sprockets-rails (~> 2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -38,7 +39,6 @@ GEM
       tzinfo (~> 0.3.37)
     arel (4.0.0)
     atomic (1.1.14)
-    atomic (1.1.14-java)
     builder (3.1.4)
     coderay (1.0.9)
     daemons (1.1.9)
@@ -77,14 +77,6 @@ GEM
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rails (4.0.0)
-      actionmailer (= 4.0.0)
-      actionpack (= 4.0.0)
-      activerecord (= 4.0.0)
-      activesupport (= 4.0.0)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.0.0)
-      sprockets-rails (~> 2.0.0)
     railties (4.0.0)
       actionpack (= 4.0.0)
       activesupport (= 4.0.0)
@@ -115,8 +107,6 @@ GEM
     thor (0.18.1)
     thread_safe (0.1.3)
       atomic
-    thread_safe (0.1.3-java)
-      atomic
     tilt (1.4.1)
     treetop (1.4.15)
       polyglot
@@ -128,6 +118,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailer (~> 4.0.0)
+  activerecord (~> 4.0.0)
   activerecord-jdbcsqlite3-adapter
   mocha
   pry-rails

--- a/app/models/web_console/console_session.rb
+++ b/app/models/web_console/console_session.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 module WebConsole
   # Manage and persist (in memory) WebConsole::Slave instances.
   class ConsoleSession

--- a/lib/web_console/engine.rb
+++ b/lib/web_console/engine.rb
@@ -2,6 +2,9 @@ require 'ipaddr'
 require 'active_support/core_ext/numeric/time'
 require 'rails/engine'
 
+require 'active_model'
+require 'sprockets/rails'
+
 module WebConsole
   class Engine < ::Rails::Engine
     isolate_namespace WebConsole

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -14,6 +14,13 @@ Gem::Specification.new do |s|
   s.files      = Dir["{app,config,db,lib,vendor}/**/*", "MIT-LICENSE", "Rakefile", "README.markdown"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.0.0"
-  s.add_dependency "activemodel", "~> 4.0.0"
+  rails_version = "~> 4.0.0"
+
+  s.add_dependency "railties",        rails_version
+  s.add_dependency "activemodel",     rails_version
+  s.add_dependency "sprockets-rails", "~> 2.0.0"
+
+  # We need those for the testing application to run.
+  s.add_development_dependency "actionmailer", rails_version
+  s.add_development_dependency "activerecord", rails_version
 end


### PR DESCRIPTION
This change breaks the dependency of the whole `rails` meta-package, grabbing only the gems we really need.
