### PR TITLE
An 'Unpermitted Parameter' exception is raised for id in Rails 4.0.2

### DIFF
--- a/app/controllers/web_console/console_sessions_controller.rb
+++ b/app/controllers/web_console/console_sessions_controller.rb
@@ -37,7 +37,7 @@ module WebConsole
     private
 
       def console_session_params
-        params.permit(:input, :width, :height)
+        params.permit(:id, :input, :width, :height)
       end
   end
 end


### PR DESCRIPTION
An `UnpermittedParameters (found unpermitted parameters: id)` exception is raised when running the console in Rails 4.0.2 with `config.action_controller.action_on_unpermitted_parameters` set to `:raise` in the environment configuration.

This causes the Web Console to become unresponsive.
