### PR TITLE
Bring back the REPL adapters from the 0.2 fame

### DIFF
--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -1,4 +1,5 @@
 require 'active_support/lazy_load_hooks'
+require 'web_console/repl'
 require 'web_console/engine'
 require 'web_console/colors'
 require 'web_console/slave'

--- a/lib/web_console/fiber.rb
+++ b/lib/web_console/fiber.rb
@@ -1,0 +1,48 @@
+module WebConsole
+  # Poor Man's Fiber (API compatible Thread based Fiber implementation for Ruby 1.8)
+  # (c) 2008 Aman Gupta (tmm1)
+  #
+  # For the purposes of our REPL adapters there is a need for fiber invocation
+  # across threads. The native implementation does not support that.
+  class FiberError < StandardError; end
+
+  class Fiber
+    def initialize
+      raise ArgumentError, 'new Fiber requires a block' unless block_given?
+
+      @yield = Queue.new
+      @resume = Queue.new
+
+      @thread = Thread.new { @yield.push [ *yield(*@resume.pop) ] }
+      @thread.abort_on_exception = true
+      @thread[:fiber] = self
+    end
+    attr_reader :thread
+
+    def resume(*args)
+      raise FiberError, 'dead fiber called' unless @thread.alive?
+      @resume.push(args)
+      result = @yield.pop
+      result.size > 1 ? result : result.first
+    end
+
+    def yield(*args)
+      @yield.push(args)
+      result = @resume.pop
+      result.size > 1 ? result : result.first
+    end
+
+    def self.yield(*args)
+      raise FiberError, "can't yield from root fiber" unless fiber = Thread.current[:fiber]
+      fiber.yield(*args)
+    end
+
+    def self.current
+      Thread.current[:fiber] or raise FiberError, 'not inside a fiber'
+    end
+
+    def inspect
+      "#<#{self.class}:0x#{self.object_id.to_s(16)}>"
+    end
+  end
+end

--- a/lib/web_console/repl.rb
+++ b/lib/web_console/repl.rb
@@ -1,0 +1,60 @@
+require 'active_support/core_ext/string/inflections'
+
+module WebConsole
+  module REPL
+    extend self
+
+    # Registry of REPL implementations mapped to their correspondent adapter
+    # classes.
+    #
+    # Don't manually alter the registry. Use WebConsole::REPL.register_adapter
+    # for adding entries.
+    def adapters
+      @adapters ||= {}
+    end
+
+    # Register an adapter into the adapters registry.
+    #
+    # Registration maps and adapter class to an existing REPL implementation,
+    # that we call an adaptee constant. If the adaptee constant is not given,
+    # it is automatically derived from the adapter class name.
+    #
+    # For example, adapter named +WebConsole::REPL::IRB+ will derive the
+    # adaptee constant to +::IRB+.
+    #
+    # If a block is given, it would be evaluated right after the adapter
+    # registration.
+    def register_adapter(adapter_class, adaptee_constant = nil, options = {})
+      if adaptee_constant.is_a?(Hash)
+        options          = adaptee_constant
+        adaptee_constant = nil
+      end
+      adaptee_constant   = adapter_class if options[:standalone]
+      adaptee_constant ||= derive_adaptee_constant_from(adapter_class)
+      adapters[adaptee_constant] = adapter_class
+      yield if block_given?
+    end
+
+    # Get the default adapter for the given application.
+    #
+    # By default the application will be Rails.application and the adapter
+    # will be chosen from Rails.application.config.console.
+    #
+    # If no suitible adapter is found for the configured Rails console, a dummy
+    # adapter will be used. You can evaluate code in it, but it won't support
+    # any advanced features, like multiline code evaluation.
+    def default(app = Rails.application)
+      adapters[(app.config.console || ::IRB rescue ::IRB)] || adapters[Dummy]
+    end
+
+    private
+
+      def derive_adaptee_constant_from(cls, suffix = 'REPL')
+        "::#{cls.name.split('::').last.gsub(/#{suffix}$/i, '')}".constantize
+      end
+  end
+end
+
+# Require the builtin adapters.
+require 'web_console/repl/irb'
+require 'web_console/repl/dummy'

--- a/lib/web_console/repl/dummy.rb
+++ b/lib/web_console/repl/dummy.rb
@@ -1,0 +1,33 @@
+require 'web_console/stream'
+
+module WebConsole
+  module REPL
+    # == Dummy\ Adapter
+    #
+    # Dummy adapter that is used as a fallback for REPL with no adapters.
+    #
+    # It provides only the most basic code evaluation with no multiline code
+    # support.
+    class Dummy
+      def initialize(binding = TOPLEVEL_BINDING)
+        @binding = binding
+      end
+
+      def prompt
+        '>> '
+      end
+
+      def send_input(input)
+        eval_result = nil
+        streams_output = Stream.threadsafe_capture! do
+          eval_result = @binding.eval(input).inspect
+        end
+        "#{streams_output}=> #{eval_result}\n"
+      rescue Exception => exc
+        exc.backtrace.join("\n")
+      end
+    end
+
+    register_adapter Dummy, standalone: true
+  end
+end

--- a/lib/web_console/repl/irb.rb
+++ b/lib/web_console/repl/irb.rb
@@ -1,0 +1,55 @@
+require 'irb'
+require 'web_console/fiber'
+require 'web_console/stream'
+
+module WebConsole
+  module REPL
+    # == IRB\ Adapter
+    #
+    # Adapter for the IRB REPL, which is the default Ruby on Rails console.
+    class IRB
+      # For some reason™ we have to be ::IRB::StdioInputMethod subclass to get
+      # #prompt populated.
+      #
+      # Not a pretty OOP, but for now, we just have to deal with it.
+      class FiberInputMethod < ::IRB::StdioInputMethod
+        def initialize; end
+
+        def gets
+          @previous = Fiber.yield
+        end
+
+        def encoding
+          (@previous || '').encoding
+        end
+      end
+
+      def initialize(binding = TOPLEVEL_BINDING)
+        initialize_irb_session!
+        @input = FiberInputMethod.new
+        @irb   = ::IRB::Irb.new(::IRB::WorkSpace.new(binding), @input)
+        @fiber = Fiber.new { @irb.eval_input }.tap(&:resume)
+        finalize_irb_session!
+      end
+
+      def prompt
+        @input.prompt
+      end
+
+      def send_input(input)
+        Stream.threadsafe_capture! { @fiber.resume("#{input}\n") }
+      end
+
+      private
+
+        def initialize_irb_session!(ap_path = nil)
+          ::IRB.init_config(ap_path)
+          ::IRB.run_config unless Engine.config.web_console.prevent_irbrc_execution
+        end
+
+        def finalize_irb_session!
+          ::IRB.conf[:MAIN_CONTEXT] = @irb.context
+        end
+    end
+  end
+end

--- a/lib/web_console/stream.rb
+++ b/lib/web_console/stream.rb
@@ -1,0 +1,27 @@
+module WebConsole
+  module Stream
+    extend Mutex_m
+
+    def self.threadsafe_capture!(*streams)
+      streams = [$stdout, $stderr] if streams.empty?
+      synchronize do
+        begin
+          streams_copy = streams.collect(&:dup)
+          replacement  = Tempfile.new(name)
+          streams.each do |stream|
+            stream.reopen(replacement)
+            stream.sync = true
+          end
+          yield
+          streams.each(&:rewind)
+          replacement.read
+        ensure
+          replacement.unlink
+          streams.each_with_index do |stream, i|
+            stream.reopen(streams_copy[i])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/.irbrc
+++ b/test/fixtures/.irbrc
@@ -1,0 +1,1 @@
+$IRBRC_EXECUTED = true

--- a/test/web_console/repl/dummy_test.rb
+++ b/test/web_console/repl/dummy_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class REPLTest < ActiveSupport::TestCase
+  setup do
+    @dummy1 = @dummy = WebConsole::REPL::Dummy.new
+    @dummy2 = WebConsole::REPL::Dummy.new
+  end
+
+  test 'sending input returns the result as output' do
+    assert_equal "=> 42\n", @dummy.send_input('foo = 42')
+  end
+
+  test 'preserves the session in the binding' do
+    assert_equal "=> 42\n", @dummy.send_input('foo = 42')
+    assert_equal "=> 50\n", @dummy.send_input('foo + 8')
+  end
+
+  test 'session isolation requires own bindings' do
+    dummy1 = WebConsole::REPL::IRB.new(Object.new.instance_eval('binding'))
+    dummy2 = WebConsole::REPL::IRB.new(Object.new.instance_eval('binding'))
+    assert_equal "=> 42\n", dummy1.send_input('foo = 42')
+    assert_match %r{NameError}, dummy2.send_input('foo')
+  end
+
+  test 'session preservation requires same bindings' do
+    assert_equal "=> 42\n", @dummy1.send_input('foo = 42')
+    assert_equal "=> 42\n", @dummy2.send_input('foo')
+  end
+
+  test 'captures stdout output' do
+    assert_equal "42\n=> nil\n", @dummy.send_input('puts 42')
+  end
+
+  test 'captures stderr output' do
+    assert_equal "42\n=> 3\n", @dummy.send_input('$stderr.write("42\n")')
+  end
+
+  test 'prompt is present' do
+    assert_not_nil @dummy.prompt
+  end
+end

--- a/test/web_console/repl/irb_test.rb
+++ b/test/web_console/repl/irb_test.rb
@@ -1,0 +1,131 @@
+require 'test_helper'
+
+class IRBTest < ActiveSupport::TestCase
+  setup do
+    @irb1 = @irb = WebConsole::REPL::IRB.new
+    @irb2 = WebConsole::REPL::IRB.new
+
+    # Flag to signalize that the .irbrc was read.
+    $IRBRC_EXECUTED = false
+
+    # Since IRB is kinda funky, it reads the .irbrc in $HOME/.irbrc earlier
+    # that the one in the current working directory, we have to lie to it.
+    @preserved_home, ENV['HOME'] = ENV['HOME'], nil
+
+    # It also caches the procedure used to generate the .irbrc location.
+    IRB.conf[:RC_NAME_GENERATOR] = nil
+  end
+
+  teardown do
+    # Now, bring the working place as we have found it.
+    ENV['HOME'] = @preserved_home
+    WebConsole::Engine.config.web_console.prevent_irbrc_execution = false
+  end
+
+  test 'sending input returns the result as output' do
+    assert_equal return_prompt(42), @irb.send_input('foo = 42')
+  end
+
+  test 'preserves the session in the binding' do
+    assert_equal return_prompt(42), @irb.send_input('foo = 42')
+    assert_equal return_prompt(50), @irb.send_input('foo + 8')
+  end
+
+  test 'session isolation requires own bindings' do
+    irb1 = WebConsole::REPL::IRB.new(Object.new.instance_eval('binding'))
+    irb2 = WebConsole::REPL::IRB.new(Object.new.instance_eval('binding'))
+    assert_equal return_prompt(42), irb1.send_input('foo = 42')
+    assert_match %r{NameError}, irb2.send_input('foo')
+  end
+
+  test 'session preservation requires same bindings' do
+    assert_equal return_prompt(42), @irb1.send_input('foo = 42')
+    assert_equal return_prompt(42), @irb2.send_input('foo')
+  end
+
+  test 'multiline sessions' do
+    irb = WebConsole::REPL::IRB.new(Object.new.instance_eval('binding'))
+    assert_equal "", irb.send_input('class A')
+    assert_equal return_prompt('nil'), irb.send_input('end')
+    assert_no_match %r{NameError}, irb.send_input('A')
+  end
+
+  test 'captures direct stdout output' do
+    assert_equal "42\n#{return_prompt('nil')}", @irb.send_input('puts 42')
+  end
+
+  test 'captures direct stderr output' do
+    assert_equal "42\n#{return_prompt(3)}", @irb.send_input('$stderr.write("42\n")')
+  end
+
+  test 'captures direct output from subprocesses' do
+    assert_equal "42\n#{return_prompt(true)}", @irb.send_input('system "echo 42"')
+  end
+
+  test 'captures direct output from forks' do
+    # This is a bummer, but currently I don't see how we can work around it,
+    # without monkey patching fork and the crew to be blocking calls. This
+    # won't scale well, but at least fork will show results. Otherwise, we can
+    # document the behaviour and expect the user to wait themselves, if they
+    # care about the output.
+    assert_match %r{42\n}, @irb.send_input('Process.wait(fork { puts 42 })')
+  end
+
+  test 'multiline support between threads' do
+    assert_equal "", @irb.send_input('class A')
+    Thread.new do
+      assert_equal return_prompt('nil'), @irb.send_input('end')
+      assert_no_match %r{NameError}, @irb.send_input('A')
+    end.join
+  end
+
+  test 'prompt is present' do
+    assert_not_nil @irb.prompt
+  end
+
+  test 'prompt is determined by ::IRB.conf' do
+    with_simple_prompt do
+      assert '>> ', WebConsole::REPL::IRB.new.prompt
+    end
+  end
+
+  private
+
+    def currently_selected_prompt
+      ::IRB.conf[:PROMPT][::IRB.conf[:PROMPT_MODE]]
+    end
+
+    def return_prompt(*args)
+      sprintf(currently_selected_prompt[:RETURN], *args)
+    end
+
+    def input_prompt
+      currently_selected_prompt[:PROMPT_I]
+    end
+
+    def with_simple_prompt
+      previous_prompt = ::IRB.conf[:PROMPT]
+      ::IRB.conf[:PROMPT] = :simple
+      yield
+    ensure
+      ::IRB.conf[:PROMPT] = previous_prompt
+    end
+
+    def new_uninitialized_app(root = File.expand_path('../../../dummy', __FILE__))
+      FileUtils.mkdir_p root
+      Dir.chdir root
+
+      old_app = Rails.application
+      Rails.application = nil
+
+      app = Class.new(Rails::Application)
+      app.config.eager_load = false
+      app.config.time_zone = 'UTC'
+      app.config.middleware ||= Rails::Configuration::MiddlewareStackProxy.new
+      app.config.active_support.deprecation = :notify
+
+      yield app
+    ensure
+      Rails.application = old_app
+    end
+end

--- a/test/web_console/repl_test.rb
+++ b/test/web_console/repl_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class REPLTest < ActiveSupport::TestCase
+  test 'standalone adapter registration' do
+    WebConsole::REPL::register_adapter adapter = Class.new, standalone: true
+    assert_equal adapter, WebConsole::REPL::adapters[adapter]
+  end
+
+  test 'fallback for unsupported config.console' do
+    app_mock = Class.new do
+      define_singleton_method(:config) { OpenStruct.new(console: Class.new) }
+    end
+    assert_equal WebConsole::REPL::Dummy, WebConsole::REPL.default(app_mock)
+  end
+end


### PR DESCRIPTION
During this GSoC, we would like to focus our efforts on making the web-console introspect the current process and possibly to integrate itself into the default Rails error pages. To do that we need a mechanism to execute Ruby code in an arbitrary binding. Luckily, we already have some code from the 0.{1,2} days, that used to do that and we can reuse it as a start.
