### PR TITLE
Delay PTY utilities require as windows doesn't support them

### DIFF
--- a/lib/web_console/slave.rb
+++ b/lib/web_console/slave.rb
@@ -1,6 +1,3 @@
-require 'pty'
-require 'io/console'
-
 module WebConsole
   # = Slave\ Process\ Wrapper
   #
@@ -21,6 +18,11 @@ module WebConsole
     attr_reader :pid
 
     def initialize(command = WebConsole.config.command, options = {})
+      # Windows doesn't have PTY, requiring it at the top level will fail the
+      # whole program execution.
+      require 'pty'
+      require 'io/console'
+
       using_term(options[:term] || WebConsole.config.term) do
         @output, @input, @pid = PTY.spawn(command.to_s)
       end


### PR DESCRIPTION
A couple of users reported this on the upstream Ruby on Rails tracker. See rails/rails#16786 and rails/rails#16783 for background.
