### PR TITLE
Fix plus sign in console

### DIFF
--- a/lib/action_dispatch/debug_exceptions.rb
+++ b/lib/action_dispatch/debug_exceptions.rb
@@ -6,7 +6,7 @@ module ActionDispatch
       request = Request.new(env)
 
       if request.put? && m = env["PATH_INFO"].match(%r{/repl_sessions/(?<id>.+?)\z})
-        raw_input = request.raw_post.split('=')[1]
+        raw_input = request.raw_post.partition('=').last
         update_repl_session(m[:id], raw_input)
       elsif request.post? && m = env["PATH_INFO"].match(%r{/repl_sessions/(?<id>.+?)/trace\z})
         change_stack_trace(m[:id], request.params[:frame_id])


### PR DESCRIPTION
Not sure where to test this, it looks like middleware isn't covered in the current tests. If there's a way to do it, let me know.

Anyway, this patch allows you to add numbers in the console.

Previously:

```
>> 1+1
!! #<SyntaxError: /Users/milan/Projects/testapp/app/controllers/users_controller.rb:7: syntax error, unexpected tINTEGER, expecting end-of-input>
```

Now:

```
>> 1+1
=> 2
```

The explanation: The plus sign was getting lost when request.params were generated.
