### PR TITLE
Fixed naming in routes for tests_controller

### DIFF
--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get :helper_test, to: "helper_test#index"
   get :controller_helper_test, to: "controller_helper_test#index"
 
-  resource :test do
+  namespace :tests do
     get :render_console_ontop_of_text
     get :renders_console_only_once
     get :doesnt_render_console_on_non_html_requests


### PR DESCRIPTION
The tests failed saying no route matches with controller test, this fixes it to match the controller name (tests)
