### PR TITLE
Introduce basic Rubinius support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-2
+    - rvm: jruby
     - gemfile: Gemfile
     - gemfile: gemfiles/Gemfile-4-1-stable
 before_install:

--- a/lib/web_console/core_ext/exception.rb
+++ b/lib/web_console/core_ext/exception.rb
@@ -1,59 +1,7 @@
-class Exception
-  begin
-    # We share the same exception binding extraction mechanism as better_errors,
-    # so try to use it if it is already available. It also solves problems like
-    # charliesome/better_errors#272, caused by an infinite recursion.
-    require 'better_errors'
-
-    # The bindings in which the exception originated in.
-    def bindings
-      @bindings || __better_errors_bindings_stack
-    end
-  rescue LoadError
-    # The bindings in which the exception originated in.
-    def bindings
-      @bindings || []
-    end
-
-    # CRuby calls #set_backtrace every time it raises an exception. Overriding
-    # it to assign the #bindings.
-    def set_backtrace_with_binding_of_caller(*args)
-      # Thanks to @charliesome who wrote this bit for better_errors.
-      unless Thread.current[:__web_console_exception_lock]
-        Thread.current[:__web_console_exception_lock] = true
-        begin
-          # Raising an exception here will cause all of the rubies to go into a
-          # stack overflow. Some rubies may even segfault. See
-          # https://bugs.ruby-lang.org/issues/10164 for details.
-          @bindings = binding.callers.drop(1)
-        ensure
-          Thread.current[:__web_console_exception_lock] = false
-        end
-      end
-
-      set_backtrace_without_binding_of_caller(*args)
-    end
-
-    alias_method_chain :set_backtrace, :binding_of_caller
-  end
-
-  if RUBY_PLATFORM =~ /java/
-    # JRuby won't call Exception#set_backtrace when raising, so we can't hook in
-    # there. Our best bet is to hook into Exception#initialize, however we have
-    # the problem that a subclass may forget to call super in its override.
-    def initialize_with_binding_of_caller(*args)
-      unless Thread.current[:__web_console_exception_lock]
-        Thread.current[:__web_console_exception_lock] = true
-        begin
-          @bindings = binding.callers.drop(1)
-        ensure
-          Thread.current[:__web_console_exception_lock] = false
-        end
-      end
-
-      initialize_without_binding_of_caller(*args)
-    end
-
-    alias_method_chain :initialize, :binding_of_caller
-  end
+if defined? JRUBY_VERSION
+  require 'web_console/core_ext/exception/jruby'
+elsif RUBY_ENGINE == 'rbx'
+  require 'web_console/core_ext/exception/rubinius'
+else
+  require 'web_console/core_ext/exception/cruby'
 end

--- a/lib/web_console/core_ext/exception/cruby.rb
+++ b/lib/web_console/core_ext/exception/cruby.rb
@@ -1,0 +1,39 @@
+class Exception
+  begin
+    # We share the same exception binding extraction mechanism as better_errors,
+    # so try to use it if it is already available. It also solves problems like
+    # charliesome/better_errors#272, caused by an infinite recursion.
+    require 'better_errors'
+
+    # The bindings in which the exception originated in.
+    def bindings
+      @bindings || __better_errors_bindings_stack
+    end
+  rescue LoadError
+    # The bindings in which the exception originated in.
+    def bindings
+      @bindings || []
+    end
+
+    # CRuby calls #set_backtrace every time it raises an exception. Overriding
+    # it to assign the #bindings.
+    def set_backtrace_with_binding_of_caller(*args)
+      # Thanks to @charliesome who wrote this bit for better_errors.
+      unless Thread.current[:__web_console_exception_lock]
+        Thread.current[:__web_console_exception_lock] = true
+        begin
+          # Raising an exception here will cause all of the rubies to go into a
+          # stack overflow. Some rubies may even segfault. See
+          # https://bugs.ruby-lang.org/issues/10164 for details.
+          @bindings = binding.callers.drop(1)
+        ensure
+          Thread.current[:__web_console_exception_lock] = false
+        end
+      end
+
+      set_backtrace_without_binding_of_caller(*args)
+    end
+
+    alias_method_chain :set_backtrace, :binding_of_caller
+  end
+end

--- a/lib/web_console/core_ext/exception/jruby.rb
+++ b/lib/web_console/core_ext/exception/jruby.rb
@@ -1,0 +1,25 @@
+class Exception
+  # The bindings in which the exception originated in.
+  def bindings
+    @bindings || []
+  end
+
+  # JRuby won't call Exception#set_backtrace when raising, so we can't hook in
+  # there. Our best bet is to hook into Exception#initialize, however we have
+  # the problem that a subclass may forget to call super in its override.
+  def initialize_with_binding_of_caller(*args)
+    unless Thread.current[:__web_console_exception_lock]
+      Thread.current[:__web_console_exception_lock] = true
+      begin
+        @bindings = binding.callers.drop(1)
+      ensure
+        Thread.current[:__web_console_exception_lock] = false
+      end
+    end
+
+    initialize_without_binding_of_caller(*args)
+  end
+
+  alias_method_chain :initialize, :binding_of_caller
+end
+

--- a/lib/web_console/core_ext/exception/rubinius.rb
+++ b/lib/web_console/core_ext/exception/rubinius.rb
@@ -1,0 +1,32 @@
+class Exception
+  # The bindings in which the exception originated in.
+  def bindings
+    @bindings || []
+  end
+
+  # Rubinius, as JRuby, won't call Exception#set_backtrace. This means we'll
+  # miss custom exceptions overriding #initialize, but forgetting to call
+  # super.
+  def initialize_with_binding_of_caller(*args)
+    unless Thread.current[:__web_console_exception_lock]
+      Thread.current[:__web_console_exception_lock] = true
+      begin
+        @bindings = binding.callers.drop(2)
+
+        # When explicitly raising an exception, we have to drop one more frame
+        # on Rubinius. The way we do it is pretty bad as it strongly depends on
+        # the Kerner#raise implementation details. We need to do better in the
+        # future.
+        if _ = @bindings.first and _.eval('local_variables') == [:exc, :msg, :ctx, :skip, :loc, :pos]
+          @bindings.shift
+        end
+      ensure
+        Thread.current[:__web_console_exception_lock] = false
+      end
+    end
+
+    initialize_without_binding_of_caller(*args)
+  end
+
+  alias_method_chain :initialize, :binding_of_caller
+end

--- a/lib/web_console/repl_session.rb
+++ b/lib/web_console/repl_session.rb
@@ -58,7 +58,7 @@ module WebConsole
 
       # Returns a hash of the attributes and their values.
       def attributes
-        return Hash[ATTRIBUTES.zip([nil])]
+        return Hash[ATTRIBUTES.zip([nil])].except(:binding, :binding_stack)
       end
 
       # Sets model attributes from a hash.

--- a/lib/web_console/unsupported_platforms.rb
+++ b/lib/web_console/unsupported_platforms.rb
@@ -14,10 +14,6 @@ module WebConsole
 
         yield if compile_mode != interpreted_mode
       end
-
-      def rubinius
-        yield if RUBY_ENGINE == 'rbx'
-      end
     end
 
     jruby_in_non_interpreted_mode do
@@ -26,12 +22,6 @@ module WebConsole
 
         To turn on interpreted mode, put -J-Djruby.compile.mode=OFF in the
         JRUBY_OPTS environment variable.
-      END
-    end
-
-    rubinius do
-      warn <<-END.strip_heredoc
-        Web Console doesn't support Rubinius yet.
       END
     end
   end

--- a/test/dummy/app/controllers/exception_test_controller.rb
+++ b/test/dummy/app/controllers/exception_test_controller.rb
@@ -10,6 +10,6 @@ class ExceptionTestController < ApplicationController
 
   def test_method
     test2 = "Test2"
-    raise
+    raise StandardError
   end
 end

--- a/test/web_console/core_ext/exception_test.rb
+++ b/test/web_console/core_ext/exception_test.rb
@@ -2,20 +2,22 @@ require 'test_helper'
 
 module WebConsole
   class ExceptionTest < ActiveSupport::TestCase
-    module TestScenarionWithNestedCalls
-      extend self
-
+    class TestScenarionWithNestedCalls
       def call
         raise_an_error
       rescue => exc
         exc
       end
 
-      def raise_an_error
-        unused_local_variable = 42
-        raise
-      end
+      private
+
+        def raise_an_error
+          unused_local_variable = 42
+          raise
+        end
     end
+
+    CustomError = Class.new(StandardError)
 
     test '#bindings all the bindings of where the error originated' do
       begin
@@ -26,8 +28,18 @@ module WebConsole
       end
     end
 
+    test '#bindings all the bindings of where the error originated from a custom error' do
+      begin
+        unused_local_variable = "Test"
+        raise CustomError
+      rescue => exc
+        assert_equal 'Test', exc.bindings.first.eval('unused_local_variable')
+      end
+    end
+
     test '#bindings goes down the stack' do
-      exc = TestScenarionWithNestedCalls.call
+      exc = TestScenarionWithNestedCalls.new.call
+
       assert_equal 42, exc.bindings.first.eval('unused_local_variable')
     end
   end


### PR DESCRIPTION
This one didn't see the testing it deserved and can be implemented
better by using Rubinius internals, rather then this shaky
`binding_of_caller` frame guessing. For now, I wanna roll this out as a
experimental Rubinius support. We'll make it better post `2.0`.

I'm seeing gem installation errors on Travis at the moment. Both for
Rubinius and JRuby. I really wanna get them off the allowed failures, so
I'm gonna keep an eye out in the upcoming days.
