### PR TITLE
Format console errors similarly to IRB

### DIFF
--- a/lib/web_console/repl.rb
+++ b/lib/web_console/repl.rb
@@ -1,9 +1,13 @@
 module WebConsole
-  # Simple REPL implementation.
-  # It uses @binding.eval for code evaluation.
-  # No styling or console configurations is supported.
+  # Simple read–eval–print implementation.
+  #
+  # Provides only the most basic code evaluation with no multiline code
+  # support.
   class REPL
-    attr_accessor :binding
+    # Cleanses exceptions raised inside #send_input.
+    cattr_reader :cleaner
+    @@cleaner = ActiveSupport::BacktraceCleaner.new
+    @@cleaner.add_silencer { |line| line.start_with?(File.expand_path('..', __FILE__)) }
 
     def initialize(binding = TOPLEVEL_BINDING)
       @binding = binding
@@ -14,11 +18,19 @@ module WebConsole
     end
 
     def send_input(input)
-      eval_result = nil
-      eval_result = @binding.eval(input).inspect
-      "=> #{eval_result}\n"
+      "=> #{@binding.eval(input).inspect}\n"
     rescue Exception => exc
-      "!! #{exc.inspect rescue exc.class.to_s rescue "Exception"}\n"
+      format_exception(exc)
     end
+
+    private
+
+      def format_exception(exc)
+        backtrace = cleaner.clean(Array(exc.backtrace) - caller)
+
+        format = "#{exc.class.name}: #{exc}\n"
+        format << backtrace.map { |trace| "\tfrom #{trace}\n" }.join
+        format
+      end
   end
 end

--- a/test/web_console/repl_test.rb
+++ b/test/web_console/repl_test.rb
@@ -1,6 +1,21 @@
 require 'test_helper'
 
 class REPLTest < ActiveSupport::TestCase
+  class TestError < StandardError
+    def backtrace
+      [
+        "/web-console/lib/web_console/repl.rb:16:in `eval'",
+        "/web-console/lib/web_console/repl.rb:16:in `send_input'"
+      ]
+    end
+  end
+
+  class BadlyDefinedError < StandardError
+    def backtrace
+      nil
+    end
+  end
+
   setup do
     @repl1 = @repl = WebConsole::REPL.new
     @repl2         = WebConsole::REPL.new
@@ -23,4 +38,38 @@ class REPLTest < ActiveSupport::TestCase
   test 'prompt is present' do
     assert_not_nil @repl.prompt
   end
+
+  test 'formats exceptions similarly to IRB' do
+    repl = WebConsole::REPL.new(binding)
+
+    assert_equal <<-END.strip_heredoc, repl.send_input("raise TestError, 'panic'")
+      #{TestError.name}: panic
+      \tfrom /web-console/lib/web_console/repl.rb:16:in `eval'
+      \tfrom /web-console/lib/web_console/repl.rb:16:in `send_input'
+    END
+  end
+
+  test 'no backtrace is shown if exception backtrace is blank' do
+    repl = WebConsole::REPL.new(binding)
+
+    assert_equal <<-END.strip_heredoc, repl.send_input("raise BadlyDefinedError")
+      #{BadlyDefinedError.name}: #{BadlyDefinedError.name}
+    END
+  end
+
+  test 'WebConsole::REPL callers are cleaned up of unneeded backtraces' do
+    # Those have to be on the same line to get the same trace.
+    repl, trace = WebConsole::REPL.new(binding), current_trace
+
+    assert_equal <<-END.strip_heredoc, repl.send_input("raise")
+      RuntimeError: 
+      \tfrom #{trace}
+    END
+  end
+
+  private
+
+    def current_trace
+      caller.first
+    end
 end


### PR DESCRIPTION
Currently, if an exception is raised during console input sending,
it will look like:

```
>> raise
!! RuntimeError
```

Now, we can show a backtrace in a similar format to IRB. It will be
cleaned up of the framework traces until the REPL for noiseless
debugging.

```
>> request.missing
NoMethodError: undefined method `missing' for #<ActionDispatch::Request:0x007fb6228197e8>
    from /web-console/test/dummy/app/controllers/exception_test_controller.rb:13:in `test_method'
```
