### PR TITLE
Align the implementation with upstream Rails

### DIFF
--- a/lib/action_dispatch/exception_wrapper.rb
+++ b/lib/action_dispatch/exception_wrapper.rb
@@ -1,5 +1,27 @@
 module ActionDispatch
   class ExceptionWrapper
+    def traces
+      appplication_trace_with_ids = []
+      framework_trace_with_ids = []
+      full_trace_with_ids = []
+
+      if full_trace
+        full_trace.each_with_index do |trace, idx|
+          trace_with_id = { id: idx, trace: trace }
+
+          appplication_trace_with_ids << trace_with_id if application_trace.include?(trace)
+          framework_trace_with_ids << trace_with_id if framework_trace.include?(trace)
+          full_trace_with_ids << trace_with_id
+        end
+      end
+
+      {
+        "Application Trace" => appplication_trace_with_ids,
+        "Framework Trace" => framework_trace_with_ids,
+        "Full Trace" => full_trace_with_ids
+      }
+    end
+
     def extract_sources
       exception.backtrace.map do |trace|
         file, line  = trace.split(":")

--- a/lib/action_dispatch/templates/rescues/_source.erb
+++ b/lib/action_dispatch/templates/rescues/_source.erb
@@ -1,15 +1,16 @@
-<% if @extract_sources %>
-  <% @extract_sources.each_with_index do |extract_source, index| %>
-    <div class="source <%="hidden" if @show_source_idx != index%>" id="frame-source-<%=index%>">
-      <div class="info">
-        Extracted source (around line <strong>#<%= extract_source[:line_number] %></strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
+<% if @source_extract %>
+  <% @source_extract.each_with_index do |extract_source, index| %>
+    <% if extract_source[:code] %>
+      <div class="source <%="hidden" if @show_source_idx != index%>" id="frame-source-<%=index%>">
+        <div class="info">
+          Extracted source (around line <strong>#<%= extract_source[:line_number] %></strong>):
+        </div>
+        <div class="data">
+          <table cellpadding="0" cellspacing="0" class="lines">
             <tr>
               <td>
                 <pre class="line_numbers">
-                  <% extract_source[:code].keys.each do |line_number| %>
+                  <% extract_source[:code].each_key do |line_number| %>
 <span><%= line_number -%></span>
                   <% end %>
                 </pre>
@@ -20,8 +21,9 @@
 </pre>
 </td>
             </tr>
-        </table>
+          </table>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/lib/action_dispatch/templates/rescues/_trace.html.erb
+++ b/lib/action_dispatch/templates/rescues/_trace.html.erb
@@ -1,16 +1,18 @@
+<% names = @traces.keys %>
+
 <p><code>Rails.root: <%= defined?(Rails) && Rails.respond_to?(:root) ? Rails.root : "unset" %></code></p>
 
 <div id="traces">
-  <% @trace_names.each do |key, name| %>
+  <% names.each do |name| %>
     <%
-      show = "show('#{key}');"
-      hide = (@trace_names.keys - [key]).collect {|hide_name| "hide('#{hide_name}');"}
+      show = "show('#{name.gsub(/\s/, '-')}');"
+      hide = (names - [name]).collect {|hide_name| "hide('#{hide_name.gsub(/\s/, '-')}');"}
     %>
-    <a href="#" onclick="<%= hide.join %><%= show %>; return false;"><%= name %></a> <%= '|' unless @trace_names.keys.last == key %>
+    <a href="#" onclick="<%= hide.join %><%= show %>; return false;"><%= name %></a> <%= '|' unless names.last == name %>
   <% end %>
 
-  <% @traces.each do |key, trace| %>
-    <div id="<%= key %>" style="display: <%= (key == @trace_to_show) ? 'block' : 'none' %>;">
+  <% @traces.each do |name, trace| %>
+    <div id="<%= name.gsub(/\s/, '-') %>" style="display: <%= (name == @trace_to_show) ? 'block' : 'none' %>;">
       <pre><code><% trace.each do |frame| %><a class="trace-frames" data-frame-id="<%= frame[:id] %>" href="#"><%= frame[:trace] %></a><br><% end %></code></pre>
     </div>
   <% end %>

--- a/lib/action_dispatch/templates/rescues/_trace.text.erb
+++ b/lib/action_dispatch/templates/rescues/_trace.text.erb
@@ -3,7 +3,7 @@ Rails.root: <%= defined?(Rails) && Rails.respond_to?(:root) ? Rails.root : "unse
 <% @traces.each do |name, trace| %>
 <% if trace.any? %>
 <%= name %>
-<%= trace.join("\n") %>
+<%= trace.map { |t| t[:trace] }.join("\n") %>
 
 <% end %>
 <% end %>

--- a/lib/action_dispatch/templates/rescues/layout.erb
+++ b/lib/action_dispatch/templates/rescues/layout.erb
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8" />
   <title>Action Controller: Exception caught</title>
-
   <style>
     body {
       background-color: #FAFAFA;
@@ -44,10 +43,6 @@
     h2 {
       color: #C52F24;
       line-height: 25px;
-    }
-
-    .hidden {
-      display: none;
     }
 
     .details {
@@ -121,6 +116,10 @@
       background-color: #FFCCCC;
     }
 
+    .hidden {
+      display: none;
+    }
+
     a { color: #980905; }
     a:visited { color: #666; }
     a.trace-frames { color: #666; }
@@ -129,7 +128,6 @@
 
     <%= yield :style %>
   </style>
-
 
   <script>
     var toggle = function(id) {

--- a/lib/action_dispatch/templates/rescues/missing_template.html.erb
+++ b/lib/action_dispatch/templates/rescues/missing_template.html.erb
@@ -4,4 +4,10 @@
 
 <div id="container">
   <h2><%= h @exception.message %></h2>
+
+  <%= render template: "rescues/_source" %>
+  <%= render template: "rescues/_trace" %>
+  <%= render template: "rescues/_request_and_response" %>
 </div>
+
+<%= render template: "rescues/_web_console" %>

--- a/lib/action_dispatch/templates/rescues/routing_error.html.erb
+++ b/lib/action_dispatch/templates/rescues/routing_error.html.erb
@@ -27,4 +27,8 @@
 
     <%= @routes_inspector.format(ActionDispatch::Routing::HtmlTableFormatter.new(self)) %>
   <% end %>
+
+  <%= render template: "rescues/_request_and_response" %>
 </div>
+
+<%= render template: "rescues/_web_console" %>

--- a/lib/action_dispatch/templates/rescues/template_error.text.erb
+++ b/lib/action_dispatch/templates/rescues/template_error.text.erb
@@ -1,4 +1,3 @@
-<% @source_extract = @exception.source_extract(0, :html) %>
 <%= @exception.original_exception.class.to_s %> in <%= @request.parameters["controller"].camelize if @request.parameters["controller"] %>#<%= @request.parameters["action"] %>
 
 Showing <%= @exception.file_name %> where line #<%= @exception.line_number %> raised:

--- a/lib/action_dispatch/templates/routes/_table.html.erb
+++ b/lib/action_dispatch/templates/routes/_table.html.erb
@@ -1,6 +1,6 @@
 <% content_for :style do %>
   #route_table {
-    margin: 0 auto 0;
+    margin: 0;
     border-collapse: collapse;
   }
 


### PR DESCRIPTION
This one aligns the implementation and the templates with upstream Rails. It fixes #72 as it adds consoles on all error pages. It also tries to fix #71, so we no longer manipulate the exception for other middleware friends.

Once #69 is ready, we won't be needing to do this again.
