### PR TITLE
Add web_console gemspec

### DIFF
--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -7,21 +7,22 @@ Gem::Specification.new do |s|
   s.version  = WebConsole::VERSION
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
   s.email    = ["gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
-  s.homepage = "https://github.com/rails/web-console"
-  s.summary  = "Rails Console on the Browser."
+  s.homepage = "https://github.com/rails/web_console"
+  s.summary  = "A set of debugging tools for your Rails application."
   s.license  = 'MIT'
+  s.files    = []
 
-  s.files      = Dir["{app,config,db,lib,vendor}/**/*", "MIT-LICENSE", "Rakefile", "README.markdown"]
-  s.test_files = Dir["test/**/*"]
+  s.add_dependency "web_console", WebConsole::VERSION
 
-  rails_version = "~> 4.0"
+  s.post_install_message = <<-END
+#######################################################
 
-  s.add_dependency "railties",          rails_version
-  s.add_dependency "activemodel",       rails_version
-  s.add_dependency "sprockets-rails",   ">= 2.0", "< 4.0"
-  s.add_dependency "binding_of_caller", "0.7.3.pre1"
+The `web-console` gem has been renamed to `web_console`.
+Instead of installing `web-console`, you should install
+`web_console`.  Please update your Gemfile and other
+dependencies accordingly as the legacy `web-console`
+gem will not be updated after version 3.0.
 
-  # We need those for the testing application to run.
-  s.add_development_dependency "actionmailer", rails_version
-  s.add_development_dependency "activerecord", rails_version
+#######################################################
+END
 end

--- a/web_console.gemspec
+++ b/web_console.gemspec
@@ -1,0 +1,27 @@
+$:.push File.expand_path("../lib", __FILE__)
+
+require "web_console/version"
+
+Gem::Specification.new do |s|
+  s.name     = "web_console"
+  s.version  = WebConsole::VERSION
+  s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
+  s.email    = ["gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
+  s.homepage = "https://github.com/rails/web_console"
+  s.summary  = "A set of debugging tools for your Rails application."
+  s.license  = 'MIT'
+
+  s.files      = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown"]
+  s.test_files = Dir["test/**/*"]
+
+  rails_version = "~> 4.0"
+
+  s.add_dependency "railties",          rails_version
+  s.add_dependency "activemodel",       rails_version
+  s.add_dependency "sprockets-rails",   ">= 2.0", "< 4.0"
+  s.add_dependency "binding_of_caller", ">= 0.7.2"
+
+  # We need those for the testing application to run.
+  s.add_development_dependency "actionmailer", rails_version
+  s.add_development_dependency "activerecord", rails_version
+end


### PR DESCRIPTION
Back in the days I haven't read the [name your gem](http://guides.rubygems.org/name-your-gem/) guide. We have a
chance of fixing the name before release.
