### PR TITLE
extract_sources works with Windows paths

### DIFF
--- a/lib/action_dispatch/exception_wrapper.rb
+++ b/lib/action_dispatch/exception_wrapper.rb
@@ -24,7 +24,7 @@ module ActionDispatch
 
     def extract_sources
       exception.backtrace.map do |trace|
-        file, line = trace.match(/^(.+?):(\d+).*$/).captures
+        file, line = trace.match(/^(.+?):(\d+).*$/).try(:captures) || trace
         line_number = line.to_i
 
         {

--- a/test/action_pack/exception_wrapper_test.rb
+++ b/test/action_pack/exception_wrapper_test.rb
@@ -35,5 +35,18 @@ module ActionDispatch
         line_number: 27
       }], wrapper.extract_sources
     end
+
+    test '#extract_sources works broken backtrace' do
+      exc = TestError.new("invalid")
+
+      wrapper = ExceptionWrapper.new({}, exc)
+      wrapper.expects(:source_fragment).with('invalid', 0).returns('nothing')
+
+      assert_equal [{
+        code: 'nothing',
+        file: 'invalid',
+        line_number: 0
+      }], wrapper.extract_sources
+    end
   end
 end


### PR DESCRIPTION
Prior to this, backtrace lines were simply split by a single colon.

Unfortunately that is also the drive letter delimiter in Windows paths which resulted in a lot of empty source fragments of "C:0". ("C" from the drive letter and 0 from `"/path/to/rails/file.rb:16".to_i`)

Now the trace line is split by the first colon followed by some digits, which works for both Windows and Unix path styles.
