### PR TITLE
Improve and stabilize local and Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,3 @@ matrix:
     - rvm: rbx-2
     - rvm: jruby
     - gemfile: Gemfile
-    - gemfile: gemfiles/Gemfile-4-1-stable
-    - gemfile: gemfiles/Gemfile-4-2-stable
-

--- a/Gemfile
+++ b/Gemfile
@@ -12,17 +12,6 @@ platforms :ruby do
   gem 'sqlite3'
 end
 
-group :development do
-  gem 'puma'
-
-  # Only require this one explicitly.
-  gem 'pry-rails', require: false
-
-  platforms :ruby do
-    gem 'thin'
-  end
-end
-
 group :test do
   gem 'rake'
   gem 'mocha', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', github: 'rails/rails'
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'binding_of_caller', '0.7.3.pre1'
 end
 
 platforms :ruby do

--- a/gemfiles/Gemfile-4-0-stable
+++ b/gemfiles/Gemfile-4-0-stable
@@ -6,6 +6,7 @@ gem 'rails', github: 'rails/rails', branch: '4-0-stable'
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'binding_of_caller', '0.7.3.pre1'
 end
 
 platforms :ruby do

--- a/gemfiles/Gemfile-4-1-stable
+++ b/gemfiles/Gemfile-4-1-stable
@@ -6,6 +6,7 @@ gem 'rails', github: 'rails/rails', branch: '4-1-stable'
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'binding_of_caller', '0.7.3.pre1'
 end
 
 platforms :ruby do

--- a/gemfiles/Gemfile-4-2-stable
+++ b/gemfiles/Gemfile-4-2-stable
@@ -6,6 +6,7 @@ gem 'rails', github: 'rails/rails', branch: '4-2-stable'
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'binding_of_caller', '0.7.3.pre1'
 end
 
 platforms :ruby do

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -12,10 +12,6 @@ Dummy::Application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
-  # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
-  config.static_cache_control = "public, max-age=3600"
-
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/test/web_console/helper_test.rb
+++ b/test/web_console/helper_test.rb
@@ -47,6 +47,8 @@ module WebConsole
     end
 
     setup do
+      WebConsole.config.stubs(:whitelisted_ips).returns(IPAddr.new('0.0.0.0/0'))
+
       @app = Middleware.new(SingleConsoleApplication.new)
     end
 

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -18,6 +18,8 @@ module WebConsole
     end
 
     setup do
+      WebConsole.config.stubs(:whitelisted_ips).returns(IPAddr.new('0.0.0.0/0'))
+
       @app = Middleware.new(Application.new)
     end
 
@@ -54,6 +56,8 @@ module WebConsole
     end
 
     test "doesn't render console from non whitelisted IP" do
+      WebConsole.config.stubs(:whitelisted_ips).returns(IPAddr.new('127.0.0.1'))
+
       get '/', nil, 'CONTENT_TYPE' => 'text/html', 'REMOTE_ADDR' => '1.1.1.1', 'web-console.binding' => binding
 
       assert_select '#console', 0

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -30,7 +30,7 @@ module WebConsole
     end
 
     test 'render console in an html application from web_console.exception' do
-      get '/', nil, 'CONTENT_TYPE' => 'text/html', 'web_console.binding' => binding
+      get '/', nil, 'CONTENT_TYPE' => 'text/html', 'web_console.exception' => raise_exception
 
       assert_select '#console'
     end

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 module WebConsole
   class RequestTest < ActiveSupport::TestCase
+    setup do
+      WebConsole.config.stubs(:whitelisted_ips).returns(IPAddr.new('127.0.0.1'))
+    end
+
     test '#from_whitelited_ip? is falsy for blacklisted IPs' do
       req = request('http://example.com', 'REMOTE_ADDR' => '0.0.0.0')
 


### PR DESCRIPTION
A few things:

* Cleaned up unused development gems.
* Added pre `binding_of_caller` for JRuby tests, as they currently error out.
* Silenced a deprecation warning on Rails 4.2 stable.
* Got more strict tests by not allowing 4.1 and 4.2 stable to fail.
* Fixed a transient failure caused by blocking wrong networks.
* Fixed a mistakenly duplicated test.

JRuby and Rubinius tests are still failing because of non-portable exception formatting.
I'll address this in a separate PR.

The transient failures were happening, because sometimes, whitelisted IPs were set to
the private networks of `192.168.0.0/16` and `172.16.0.0/12` during testing, which is a
problem by its own.

Fixing this now and I'll investigate why this is happening and whether
there is a problem with the initialization code.
