### PR TITLE
Accept text/plain as acceptable content type for Puma

### DIFF
--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -1,6 +1,10 @@
 module WebConsole
   # Web Console tailored request object.
   class Request < ActionDispatch::Request
+    # While most of the servers will return blank content type if none given,
+    # Puma will return text/plain.
+    ACCEPTABLE_CONTENT_TYPE = [Mime::HTML, Mime::TEXT]
+
     # Returns whether a request came from a whitelisted IP.
     #
     # For a request to hit Web Console features, it needs to come from a white
@@ -11,10 +15,10 @@ module WebConsole
 
     # Returns whether the request is from an acceptable content type.
     #
-    # We can render a console only for HTML. If a client didn't specified any,
-    # we'll assume its HTML, because this is common.
+    # We can render a console for HTML and TEXT. If a client didn't
+    # specified any content type, we'll render it as well.
     def acceptable_content_type?
-      content_type.blank? || Mime::HTML == content_type
+      content_type.blank? || content_type.in?(ACCEPTABLE_CONTENT_TYPE)
     end
   end
 end

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -25,6 +25,12 @@ module WebConsole
       [ html, xhtml ].each { |req| assert req.acceptable_content_type? }
     end
 
+    test '#acceptable_content_type? is truthy for plain text content type' do
+      req = request('http://example.com', 'CONTENT_TYPE' => 'text/plain')
+
+      assert req.acceptable_content_type?
+    end
+
     test '#acceptable_content_type? is truthy for blank content type' do
       req = request('http://example.com', 'CONTENT_TYPE' => '')
 


### PR DESCRIPTION
While most of the servers will return blank content type if none given,
Puma will return `text/plain`.

This rendered the console unusable for Puma users. I think it should be
generally safe to render it on `text/plain` as well.