### PR TITLE
Fix console resize regression

### DIFF
--- a/lib/web_console/templates/console.js
+++ b/lib/web_console/templates/console.js
@@ -129,13 +129,14 @@ REPLConsole.prototype.install = function(container) {
 
   // Render the console.
   container.innerHTML = consoleInnerHtml;
+
   // Make the console resizable.
   document.getElementById('resizer').addEventListener('mousedown', function(ev) {
     var startY = ev.clientY;
-    var startHeight = parseInt(document.defaultView.getComputedStyle(consoleDiv).height, 10);
+    var startHeight = parseInt(document.defaultView.getComputedStyle(container).height, 10);
 
     var doDrag = function(e) {
-      consoleDiv.style.height = (startHeight + startY - e.clientY) + 'px';
+      container.style.height = (startHeight + startY - e.clientY) + 'px';
     };
 
     var stopDrag = function(e) {


### PR DESCRIPTION
The template file extraction actually caught a place where a global is
used. Because, I wrap them in a closure, this broke the resize. Its a
good thing it caught it, though. 