### PR TITLE
Lock scroll bottom on console window resize. Fixes #32.

### DIFF
--- a/lib/web_console/templates/console.js
+++ b/lib/web_console/templates/console.js
@@ -124,11 +124,15 @@ REPLConsole.prototype.install = function(container) {
 
   // Make the console resizable.
   document.getElementById('resizer').addEventListener('mousedown', function(ev) {
-    var startY = ev.clientY;
-    var startHeight = parseInt(document.defaultView.getComputedStyle(container).height, 10);
+    var startY                   = ev.clientY;
+    var startHeight              = parseInt(document.defaultView.getComputedStyle(container).height, 10);
+    var consoleInner             = document.getElementsByClassName('console-inner')[0];
+    var innerScrollTopStart      = consoleInner.scrollTop;
+    var innerClientHeightStart   = consoleInner.clientHeight;
 
     var doDrag = function(e) {
       container.style.height = (startHeight + startY - e.clientY) + 'px';
+      consoleInner.scrollTop = innerScrollTopStart + (innerClientHeightStart - consoleInner.clientHeight);
     };
 
     var stopDrag = function(e) {


### PR DESCRIPTION
On resizer mousedown, save the current scroll position. On resizer mousemove
calculate the change and adjust the scroll position. This allows the current
scroll position to lock to the bottom of the screen when resizing the console
window. Tested on the latest chrome, firefox and safari.