### PR TITLE
Revamp unavailable session response message

### DIFF
--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -96,13 +96,13 @@ module WebConsole
     test 'unavailable sessions respond to the user with a message' do
       xhr :put, '/repl_sessions/no_such_session', { input: '__LINE__' }
 
-      assert_equal({ output: 'Unavailable session' }.to_json, response.body)
+      assert_equal(404, response.status)
     end
 
     test 'unavailable sessions can occur on binding switch' do
       xhr :post, "/repl_sessions/no_such_session/trace", { frame_id: 1 }
 
-      assert_equal({ output: 'Unavailable session' }.to_json, response.body)
+      assert_equal(404, response.status)
     end
 
     private


### PR DESCRIPTION
When a user hit this message, it usually means two things:

1. The underlying server have been restarted.

2. The user runs in multi-process server and the request hit a worker,
   which doesn't store the session in memory.

I'm trying to hit the users here about the second case, since we
received yet another report of this happening and people getting
confused of why the console doesn't work.

![screen shot 2015-02-21 at 3 47 42 pm](https://cloud.githubusercontent.com/assets/604618/6314712/661414ca-b9f2-11e4-90fb-7477ade05a27.png)
