### PR TITLE
Prepare for 2.1.0 release

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,48 +1,24 @@
 # CHANGELOG
 
-## 1.0.4 (December 13, 2013)
+## master (unreleased)
 
-* Fix Rails 4.0.2 incompatibility. [[#9](https://github.com/rails/web-console/pull/9)]
+## 2.1.0
 
-## 1.0.3 (September 27, 2013)
+* [#109](https://github.com/rails/web-console/pull/109) Revamp unavailable session response message ([@gsamokovarov])
+* [#107](https://github.com/rails/web-console/pull/107) Fix pasting regression for all browsers ([@parterburn])
+* [#105](https://github.com/rails/web-console/pull/105) Lock scroll bottom on console window resize ([@noahpatterson])
+* [#104](https://github.com/rails/web-console/pull/104) Always whitelist localhost and inform users why no console is displayed ([@gsamokovarov])
+* [#100](https://github.com/rails/web-console/pull/100) Accept text/plain as acceptable content type for Puma ([@gsamokovarov])
+* [#98](https://github.com/rails/web-console/pull/98) Add arbitrary big z-index to the console ([@bglbruno])
+* [#88](https://github.com/rails/web-console/pull/88) Spelling fixes ([@jeffnv])
+* [#86](https://github.com/rails/web-console/pull/86) Disable autofocus when initializing the console ([@ryandao])
+* [#84](https://github.com/rails/web-console/pull/84) Allow Rails 5 as dependency in gemspec ([@jonatack])
+* [#69](https://github.com/rails/web-console/pull/69) Introduce middleware for request dispatch and console rendering ([@gsamokovarov])
 
-* Fallback to `rails console` if relative `bin/rails` isn't available.
-
-## 1.0.2 (September 24, 2013)
-
-* Depend on Rails 4.\* instead of 4.0.\*.
-
-## 1.0.1 (September 20, 2013
-
-* Break rails meta-package dependency. [[#5](https://github.com/rails/web-console/pull/5)]
-* Fix ActiveModel load error happening on rails -O configured apps. [[#4](https://github.com/rails/web-console/pull/4)]
-
-## 1.0.0 (September 16, 2013)
-
-* Don't throw server errors on finished slave processes.
-* Add monokai color theme.
-
-## 0.4.0 (September 6, 2013)
-
-* Drop GPL dependency of vt100.js.
-* Use term.js as vt100.js replacement.
-* Add config.web_console.term for using custom $TERM.
-* Add config.web_console.style.colors for color theming.
-* Add config.web_console.style.font for using custom fonts.
-* Fix ZSH repeating the first command argument on servers started inside a TMUX session.
-
-## 0.3.0 (August 23, 2013)
-
-* Proper VT100 emulation.
-* Add config.web_console.command to allow custom programs execution.
-* Add config.web_console.timeout to allow for long-polling, where available.
-* Remove config.web_console.prevent_irbrc_execution.
-
-## 0.2.0 (August 1, 2013)
-
-* Run closest .irbrc config while initializing IRB adapters.
-* Add config.web_console.prevent_irbrc_execution option.
-
-## 0.1.0 (July 30, 2013)
-
-* Initial release.
+[@jonatack]: https://github.com/jonatack
+[@ryandao]: https://github.com/ryandao
+[@jeffnv]: https://github.com/jeffnv
+[@gsamokovarov]: https://github.com/gsamokovarov
+[@bglbruno]: https://github.com/bglbruno
+[@noahpatterson]: https://github.com/noahpatterson
+[@parterburn]: https://github.com/parterburn

--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -4,7 +4,7 @@ require 'active_support/lazy_load_hooks'
 require 'active_support/logger'
 
 require 'web_console/integration'
-require 'web_console/engine'
+require 'web_console/railtie'
 require 'web_console/errors'
 require 'web_console/helper'
 require 'web_console/evaluator'

--- a/lib/web_console/integration/jruby.rb
+++ b/lib/web_console/integration/jruby.rb
@@ -1,4 +1,5 @@
 require 'English'
+require 'active_support/core_ext/string/strip'
 
 java_import org.jruby.RubyInstanceConfig
 

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -1,11 +1,7 @@
-require 'ipaddr'
-require 'rails/engine'
-
-require 'active_model'
-require 'sprockets/rails'
+require 'rails/railtie'
 
 module WebConsole
-  class Engine < ::Rails::Engine
+  class Railtie < ::Rails::Railtie
     config.web_console = ActiveSupport::OrderedOptions.new
     config.web_console.whitelisted_ips = %w( 127.0.0.1 ::1 )
 
@@ -51,6 +47,14 @@ module WebConsole
     initializer 'web_console.whiny_requests' do
       if config.web_console.key?(:whiny_requests)
         Middleware.whiny_requests = config.web_console.whiny_requests
+      end
+    end
+
+    # Leave this undocumented so we treat such content type misses as bugs,
+    # while still being able to help the affected users in the meantime.
+    initializer 'web_console.acceptable_content_types' do
+      if acceptable_content_types = config.web_console.acceptable_content_types
+        Request.acceptable_content_types.concat(Array(acceptable_content_types))
       end
     end
   end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,3 +1,3 @@
 module WebConsole
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/lib/web_console/whitelist.rb
+++ b/lib/web_console/whitelist.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 module WebConsole
   # Whitelist of allowed networks that can access Web Console.
   #

--- a/test/web_console/railtie_test.rb
+++ b/test/web_console/railtie_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module WebConsole
-  class EngineTest < ActiveSupport::TestCase
+  class RailtieTest < ActiveSupport::TestCase
     test 'config.whitelisted_ips sets whitelisted networks' do
       new_uninitialized_app do |app|
         app.config.web_console.whitelisted_ips = %w( 172.16.0.0/12 192.168.0.0/16 )
@@ -45,6 +45,17 @@ module WebConsole
       end
     end
 
+    test 'config.acceptable_content_types adds extra content types' do
+      preserving_acceptable_content_type do
+        new_uninitialized_app do |app|
+          app.config.web_console.acceptable_content_types = [Mime::ALL]
+          app.initialize!
+
+          assert_includes Request.acceptable_content_types, Mime::ALL
+        end
+      end
+    end
+
     private
 
       def new_uninitialized_app(root = File.expand_path('../../dummy', __FILE__))
@@ -64,6 +75,13 @@ module WebConsole
         end
       ensure
         Rails.application = old_app
+      end
+
+      def preserving_acceptable_content_type
+        acceptable_content_types = Request.acceptable_content_types.dup
+        yield
+      ensure
+        Request.acceptable_content_types = acceptable_content_types
       end
 
       def teardown_fixtures(*)

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |s|
   s.name     = "web-console"
   s.version  = WebConsole::VERSION
   s.authors  = ["Charlie Somerville", "Genadi Samokovarov", "Guillermo Iguaran", "Ryan Dao"]
-  s.email    = ["gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
+  s.email    = ["charlie@charliesomerville.com", "gsamokovarov@gmail.com", "guilleiguaran@gmail.com", "daoduyducduong@gmail.com"]
   s.homepage = "https://github.com/rails/web-console"
-  s.summary  = "A set of debugging tools for your Rails application."
+  s.summary  = "A debugging tool for your Ruby on Rails applications."
   s.license  = 'MIT'
 
   s.files      = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown"]


### PR DESCRIPTION
With Rails 4.2.1 coming soon, I think we can catch its release train and
roll out 2.1.0.

~~I have tweaked the README to reflect the recent changes and be a bit
more concise and will put in shape the changelog shortly~~. ~~Will also update
the `web-console` bit in the debugging guide on Rails upstream side.~~

~~I have one issue left for review: #109.~~

@rafaelfranca, @chancancode, @guilleiguaran ping me if you need
something else for the release.