### PR TITLE
Always allow application/x-www-form-urlencoded content type

### DIFF
--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -4,7 +4,7 @@ module WebConsole
     # While most of the servers will return blank content type if none given,
     # Puma will return text/plain.
     cattr_accessor :acceptable_content_types
-    @@acceptable_content_types = [Mime::HTML, Mime::TEXT]
+    @@acceptable_content_types = [Mime::HTML, Mime::TEXT, Mime::URL_ENCODED_FORM]
 
     # Configurable set of whitelisted networks.
     cattr_accessor :whitelisted_ips

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -31,6 +31,12 @@ module WebConsole
       assert req.acceptable_content_type?
     end
 
+    test '#acceptable_content_type? is truthy during form submission' do
+      req = request('http://example.com', 'CONTENT_TYPE' => 'application/x-www-form-urlencoded')
+
+      assert req.acceptable_content_type?
+    end
+
     test '#acceptable_content_type? is truthy for blank content type' do
       req = request('http://example.com', 'CONTENT_TYPE' => '')
 


### PR DESCRIPTION
I lot of people have reported to us that the console isn't shown. A lot
of the times this happen on POST form submissions. I think its safe for
us to always allow it.

If there are no concerns about it, I'll release 2.1.1 shortly after this
is merged.