### PR TITLE
Prepare 2.1.1 release

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## 2.1.1
+
+* [#112](https://github.com/rails/web-console/pull/112) Always allow application/x-www-form-urlencoded content type ([@gsamokovarov])
+
 ## 2.1.0
 
 * [#109](https://github.com/rails/web-console/pull/109) Revamp unavailable session response message ([@gsamokovarov])

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,3 +1,3 @@
 module WebConsole
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
The main intention for this quick release is to help the people, who
still can't get to the console on POST requests.