### PR TITLE
Prepare for 2.1.2 release

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+## 2.1.2
+
+* [#115](https://github.com/rails/web-console/pull/115) Show proper binding when raising an error in a template ([@gsamokovarov])
+* [#114](https://github.com/rails/web-console/pull/114) Fix templates non rendering, because of missing template suffix ([@gsamokovarov])
+
 ## 2.1.1
 
 * [#112](https://github.com/rails/web-console/pull/112) Always allow application/x-www-form-urlencoded content type ([@gsamokovarov])

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,3 +1,3 @@
 module WebConsole
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end


### PR DESCRIPTION
I think the recent fixes are worth of a patch release. Here are the
fixes:

* [#115]: Show proper binding when raising an error in a template
* [#114]: Fix templates non rendering, because of missing template suffix

[#115]: https://github.com/rails/web-console/pull/115
[#114]: https://github.com/rails/web-console/pull/114