### PR TITLE
Include CHANGELOG in gem

### DIFF
--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary  = "A debugging tool for your Ruby on Rails applications."
   s.license  = 'MIT'
 
-  s.files      = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown"]
+  s.files      = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown", "CHANGELOG.markdown"]
   s.test_files = Dir["test/**/*"]
 
   rails_version = ">= 4.0"


### PR DESCRIPTION
Lets users check what's new with `bundle open web-console` or similar instead of having to find the repo in the browser.