### PR TITLE
Reduce gem file size by excluding test files

### DIFF
--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.license  = 'MIT'
 
   s.files      = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown", "CHANGELOG.markdown"]
-  s.test_files = Dir["test/**/*"]
 
   rails_version = ">= 4.0"
 


### PR DESCRIPTION
We have a whole Rails application in our tests suite. It wastes a lot of
space for it to be into the package. Here are the gem sizes before and
after this change.

```
1.1M    web-console-2.1.1.gem
20K     web-console-2.1.2.gem
```

This should close #119. Thanks @mvz for reporting that.