### PR TITLE
Use alias_method instead of alias_method_chain

### DIFF
--- a/lib/web_console/extensions.rb
+++ b/lib/web_console/extensions.rb
@@ -15,5 +15,6 @@ ActionDispatch::DebugExceptions.class_eval do
     end
   end
 
-  alias_method_chain :render_exception, :web_console
+  alias_method :render_exception_without_web_console, :render_exception
+  alias_method :render_exception, :render_exception_with_web_console
 end

--- a/lib/web_console/integration/cruby.rb
+++ b/lib/web_console/integration/cruby.rb
@@ -34,6 +34,7 @@ class Exception
       set_backtrace_without_binding_of_caller(*args)
     end
 
-    alias_method_chain :set_backtrace, :binding_of_caller
+    alias_method :set_backtrace_without_binding_of_caller, :set_backtrace
+    alias_method :set_backtrace, :set_backtrace_with_binding_of_caller
   end
 end

--- a/lib/web_console/integration/rubinius.rb
+++ b/lib/web_console/integration/rubinius.rb
@@ -62,5 +62,6 @@ end
     raise_exception_without_current_bindings(exc)
   end
 
-  alias_method_chain :raise_exception, :current_bindings
+  alias_method :raise_exception_without_current_bindings, :raise_exception
+  alias_method :raise_exception, :raise_exception_with_current_bindings
 end


### PR DESCRIPTION
This is probably not an ideal implementation, but the idea is to get the ball rolling on upgrading to Module#prepend, since `alias_method_chain` is deprecated in Rails 5.0.

A simpler migration path would be to replace alias_method_chain with two
alias_methods.

WDYT?