### PR TITLE
escapeHTML escapes forward slashes

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -26,6 +26,7 @@ function escapeHTML(html) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#x27;')
+    .replace(/\//g, '&#x2F;')
     .replace(/`/g, '&#x60;');
 }
 


### PR DESCRIPTION
In the [OWASP XSS guidelines](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content), escaping the forward slash character is recommended.

I don't think there's any way to exploit the current web console JS code using an unescaped forward slash, but it doesn't hurt to be safe.