### PR TITLE
Force development only web console by default

### DIFF
--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -17,6 +17,20 @@ module WebConsole
       end
     end
 
+    initializer 'web_console.development_only' do
+      unless (config.web_console.development_only == false) || Rails.env.development?
+        abort <<-END.strip_heredoc
+          Running Web Console outside of development isn't recommended. Please,
+          keep it in the development group of your Gemfile.
+
+          If you still want to run it and know what you are doing, put this in
+          your Rails application configuration:
+
+          config.web_console.development_only = false
+        END
+      end
+    end
+
     initializer 'web_console.insert_middleware' do |app|
       app.middleware.insert_before ActionDispatch::DebugExceptions, Middleware
     end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -5,14 +5,10 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 require 'web_console'
 
-# Require pry-rails if the pry shell is explicitly requested.
-require 'pry-rails' if ENV['PRY']
-
 module Dummy
   class Application < Rails::Application
-    # When the Dummy application is ran in a docker container, the local
-    # computer address is in the 172.16.0.0/12 range. Have it whitelisted.
-    config.web_console.whitelisted_ips = %w( 127.0.0.1 172.16.0.0/12 )
+    # Run outside of the development mode so our test suite runs.
+    config.web_console.development_only = false
 
     config.active_support.test_order = :random
   end

--- a/test/web_console/railtie_test.rb
+++ b/test/web_console/railtie_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 module WebConsole
   class RailtieTest < ActiveSupport::TestCase
+    setup do
+      Railtie.any_instance.stubs(:abort)
+    end
+
     test 'config.whitelisted_ips sets whitelisted networks' do
       new_uninitialized_app do |app|
         app.config.web_console.whitelisted_ips = %w( 172.16.0.0/12 192.168.0.0/16 )
@@ -53,6 +57,26 @@ module WebConsole
 
           assert_includes Request.acceptable_content_types, Mime::ALL
         end
+      end
+    end
+
+    test 'config.development_only prevents usage outside of development' do
+      Railtie.any_instance.expects(:abort)
+
+      new_uninitialized_app do |app|
+        app.config.web_console.development_only = true
+
+        app.initialize!
+      end
+    end
+
+    test 'config.development_only can be used to allow non-development usage' do
+      Rails.env.stubs(:development?).returns(true)
+
+      new_uninitialized_app do |app|
+        app.config.web_console.development_only = false
+
+        app.initialize!
       end
     end
 


### PR DESCRIPTION
People are starting to hit more and more issues of running Web Console
in the test environment. I'm sure some people still try to even run it
on testing and staging environments, even through we try to preach
against it. I don't like that we add yet another configuration, as we
have quite a bit of those, but I think the new default behaviour is
beneficial to the users.

I tried to put a good message guiding the user should they try to use
Web Console outside of the development environment. It also includes
information on how to force the usage.

Requiring `web-console` outside of development will result in process
quitting with the following message:

```
Running Web Console outside of development isn't recommended. Please,
keep it in the development group of your Gemfile.

If you still want to run it and know what you are doing, put this in
your Rails application configuration:

config.web_console.development_only = false
```

Any suggestions on the grammar are welcome. Pinging @sh19910711 for
review and @matthewd who raised concerns about this as well.