### PR TITLE
Improve non-development abort message

### DIFF
--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -20,13 +20,17 @@ module WebConsole
     initializer 'web_console.development_only' do
       unless (config.web_console.development_only == false) || Rails.env.development?
         abort <<-END.strip_heredoc
-          Running Web Console outside of development isn't recommended. Please,
-          keep it in the development group of your Gemfile.
+          Web Console is activated in the #{Rails.env} environment, which is
+          usually a mistake. To ensure it's only activated in development
+          mode, move it to the development group of your Gemfile:
 
-          If you still want to run it and know what you are doing, put this in
-          your Rails application configuration:
+              gem 'web-console', group: :development
 
-          config.web_console.development_only = false
+          If you still want to run it the #{Rails.env} environment (and know
+          what you are doing), put this in your Rails application
+          configuration:
+
+              config.web_console.development_only = false
         END
       end
     end


### PR DESCRIPTION
Thanks to Godfrey Chan for the helping us rewording this message. I made
a couple of tweaks, including using a single space for sentence spacing,
to keep it consistent with the other messages we have.

I don't mind being typography fancy, but I'd rather do it in another
change which scope is only that. We can also re-scope this and tweak all
the messages if someone volunteers to go over the other messages. :-)

The current message in action looks like this:

```
♡  be rake test
Web Console is activated in the test environment, which is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it the test environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false
```

@chancancode, can I bother you again for review? :-)