### PR TITLE
Add JavaScript test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
 Gemfile.lock
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ sudo: false
 before_script:
   - RAILS_ENV=test bundle exec rake --rakefile=test/dummy/Rakefile db:setup
 
+script:
+  - bundle exec rake test
+  - if [[ "`ruby -v`" =~ ^ruby[[:space:]] ]]; then bundle exec rake test:templates; fi
+
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ end
 
 require 'socket'
 require 'rake/testtask'
+require 'tmpdir'
+require 'securerandom'
 
 EXPANDED_CWD = File.expand_path(File.dirname(__FILE__))
 
@@ -14,6 +16,41 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
+end
+
+namespace :test do
+  desc "Run tests for templates"
+  task :templates => "templates:all"
+
+  namespace :templates do
+    task :all   => [:daemonize, :npm, :rackup, :mocha, :kill]
+    task :serve => [:npm, :rackup]
+
+    work_dir    = Pathname(__FILE__).dirname.join("test/templates")
+    pid_file    = Pathname(Dir.tmpdir).join("web_console.#{SecureRandom.uuid}.pid")
+    server_port = 29292
+    rackup_opts = "-p #{server_port}"
+
+    task :daemonize do
+      rackup_opts += " -D -P #{pid_file}"
+    end
+
+    task :npm do
+      Dir.chdir(work_dir) { system "npm install --silent" }
+    end
+
+    task :rackup do
+      Dir.chdir(work_dir) { system "bundle exec rackup #{rackup_opts}" }
+    end
+
+    task :mocha do
+      Dir.chdir(work_dir) { system "$(npm bin)/mocha-phantomjs http://localhost:#{server_port}/html/spec_runner.html" }
+    end
+
+    task :kill do
+      system "kill #{File.read pid_file}"
+    end
+  end
 end
 
 Bundler::GemHelper.install_tasks

--- a/test/templates/config.ru
+++ b/test/templates/config.ru
@@ -1,0 +1,81 @@
+require "action_view"
+require "pathname"
+
+TEST_ROOT = Pathname(__FILE__).dirname
+
+class FakeMiddleware
+  DEFAULT_HEADERS = {"Content-Type" => "application/javascript"}
+
+  def initialize(opts)
+    @headers        = opts.fetch(:headers, DEFAULT_HEADERS)
+    @req_path_regex = opts[:req_path_regex]
+    @view_path      = opts[:view_path]
+  end
+
+  def call(env)
+    [200, headers, [render(req_path(env))]]
+  end
+
+  private
+
+  attr_reader :headers
+  attr_reader :req_path_regex
+  attr_reader :view_path
+
+  # extract target path from REQUEST_PATH
+  def req_path(env)
+    env["REQUEST_PATH"].match(req_path_regex)[1]
+  end
+
+  def render(template)
+    view.render(template: template, layout: nil)
+  end
+
+  def view
+    @view ||= create_view
+  end
+
+  def create_view
+    lookup_context = ActionView::LookupContext.new(view_path)
+    lookup_context.cache = false
+    FakeView.new(lookup_context)
+  end
+
+  class FakeView < ActionView::Base
+    def render_inlined_string(template)
+      render(template: template, layout: "layouts/inlined_string")
+    end
+  end
+end
+
+# e.g. "/node_modules/mocha/mocha.js"
+map "/node_modules" do
+  node_modules = TEST_ROOT.join("node_modules")
+  unless node_modules.directory?
+    abort "ERROR: the node_modules/ directory is not found (You must run `npm install`)"
+  end
+  run Rack::Directory.new(node_modules)
+end
+
+# test runners
+map "/html" do
+  run FakeMiddleware.new(
+    req_path_regex: %r{^/html/(.*)},
+    headers: {"Content-Type" => "text/html"},
+    view_path: TEST_ROOT.join("html"),
+  )
+end
+
+map "/spec" do
+  run FakeMiddleware.new(
+    req_path_regex: %r{^/spec/(.*)},
+    view_path: TEST_ROOT.join("spec"),
+  )
+end
+
+map "/templates" do
+  run FakeMiddleware.new(
+    req_path_regex: %r{^/templates/(.*)},
+    view_path: TEST_ROOT.join("../../lib/web_console/templates"),
+  )
+end

--- a/test/templates/html/spec_runner.html.erb
+++ b/test/templates/html/spec_runner.html.erb
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Templates Test</title>
+    <link rel="stylesheet" href="/node_modules/mocha/mocha.css" />
+  </head>
+  <body>
+    <!-- setup for mocha -->
+    <div id="mocha"></div>
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script>
+      mocha.setup('bdd');
+      mocha.reporter('html');
+    </script>
+
+    <!-- load templates -->
+    <script src="/templates/console.js"></script>
+
+    <!-- find and load test cases -->
+    <% Pathname.glob(TEST_ROOT.join "spec/**/*_spec.js") do |spec| %>
+    <script src="/<%= spec.relative_path_from TEST_ROOT %>"></script>
+    <% end %>
+
+    <!-- run tests -->
+    <script>
+      if (window.mochaPhantomJS) {
+        mochaPhantomJS.run();
+      } else {
+        mocha.run();
+      }
+    </script>
+  </body>
+</html>

--- a/test/templates/package.json
+++ b/test/templates/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "for-tests",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rails/web-console"
+  },
+  "devDependencies": {
+    "chai": "^3.0.0",
+    "mocha": "^2.2.5",
+    "mocha-phantomjs": "^3.5.3"
+  }
+}

--- a/test/templates/spec/dom_helpers_spec.js
+++ b/test/templates/spec/dom_helpers_spec.js
@@ -1,0 +1,107 @@
+var assert = chai.assert;
+
+describe("DOM helpers", function() {
+  describe("hasClass()", function() {
+    context("create a <div>", function() {
+      beforeEach(function() {
+        this.div = document.createElement("div");
+      });
+
+      context("class=hello", function() {
+        beforeEach(function() {
+          this.div.className = "hello";
+        });
+        it("should have .hello", function() {
+          assert.ok(hasClass(this.div, "hello"));
+        });
+        it("should not have .world", function() {
+          assert.notOk(hasClass(this.div, "world"));
+        });
+      });
+
+      context("class=hello world", function() {
+        beforeEach(function() {
+          this.div.className = "hello world";
+        });
+        it("should have .hello", function() {
+          assert.ok(hasClass(this.div, "hello"));
+        });
+        it("should have .world", function() {
+          assert.ok(hasClass(this.div, "world"));
+        });
+        it("should not have .not-world", function() {
+          assert.notOk(hasClass(this.div, "not-world"));
+        });
+      });
+    });
+  });
+
+  describe("addClass()", function() {
+    context("create a <div>", function() {
+      beforeEach(function() {
+        this.div = document.createElement("div");
+      });
+
+      context("addClass(div, hello)", function() {
+        beforeEach(function() {
+          addClass(this.div, "hello");
+        });
+        it("should have .hello", function() {
+          assert.ok(hasClass(this.div, "hello"));
+        });
+      });
+    });
+
+    context("create a <div class=hello>", function() {
+      beforeEach(function() {
+        this.div = document.createElement("div");
+        this.div.className = "hello";
+      });
+
+      context("addClass(div, world)", function() {
+        beforeEach(function() {
+          addClass(this.div, "world");
+        });
+        it("should have .hello", function() {
+          assert.ok(hasClass(this.div, "hello"));
+        });
+        it("should also have .world", function() {
+          assert.ok(hasClass(this.div, "world"));
+        });
+      });
+    });
+  });
+
+  describe("removeClass()", function() {
+    context("create a <div class=hello world>", function() {
+      beforeEach(function() {
+        this.div = document.createElement("div");
+        this.div.className = "hello world";
+      });
+
+      context("removeClass(hello)", function() {
+        beforeEach(function() {
+          removeClass(this.div, "hello");
+        });
+        it("should not have .hello", function() {
+          assert.notOk(hasClass(this.div, "hello"));
+        });
+        it("should have .world", function() {
+          assert.ok(hasClass(this.div, "world"));
+        });
+      });
+
+      context("removeClass(world)", function() {
+        beforeEach(function() {
+          removeClass(this.div, "world");
+        });
+        it("should have .hello", function() {
+          assert.ok(hasClass(this.div, "hello"));
+        });
+        it("should not have .world", function() {
+          assert.notOk(hasClass(this.div, "world"));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request is to add a JavaScript test environment. The main changes are as follow:

* Use Mocha to run JavaScript tests
* ~~Use CoffeeScript as a DSL only for writing JavaScript tests~~
  - ~~So, add `coffee-rails` to test dependency~~
  - ~~Let me know what do you think of this :)~~
* Add a fake rack middleware class to compile `.erb` ~~and `.coffee` (ref: 474acce25)~~
* Add a few tests with BDD style
* Add a rake task to run tests for the templates
* Run tests for the templates on Travis CI

The tests can be run on a web browser, and I've made sure that it works on Chrome 43 and Firefox 38.

#### Usage Example

Type the following command:

```shell
$ bundle exec rake test:templates
```

Otherwise:

```shell
$ bundle exec rake test:templates:serve
-> Access to http://localhost:29292/html/spec_runner.html from web browsers
```

![Screenshot](https://lh3.googleusercontent.com/wnA8sntEpxQQCvNjSh19UMhUEVM3oXi8uQbgWMs7E7I=w503-h377-no)

#### Related things

* PR #137
* rails/turbolinks#472
