### PR TITLE
Close #141: A setting is misspelled at the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -143,14 +143,14 @@ class Application < Rails::Application
 end
 ```
 
-### config.web_console.templates_path
+### config.web_console.template_paths
 
 If you wanna style the console yourself, you can place `style.css` at a
-directory pointed by `config.web_console.templates_path`:
+directory pointed by `config.web_console.template_paths`:
 
 ```ruby
 class Application < Rails::Application
-  config.web_console.templates_path = 'app/views/web_console'
+  config.web_console.template_paths = 'app/views/web_console'
 end
 ```
 

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -39,7 +39,7 @@ module WebConsole
       app.middleware.insert_before ActionDispatch::DebugExceptions, Middleware
     end
 
-    initializer 'web_console.templates_path' do
+    initializer 'web_console.template_paths' do
       if template_paths = config.web_console.template_paths
         Template.template_paths.unshift(*Array(template_paths))
       end


### PR DESCRIPTION
In #141 we found out that a setting in the README was misspelled. So, a
user wasn't able to override the styles of the console.

Thank you @sh19910711 for catching that. Can you review this?