### PR TITLE
Change 'REPLConsole.session' to store only the latest single session

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -147,6 +147,8 @@ REPLConsole.prototype.install = function(container) {
   findChild(container, 'resizer').addEventListener('mousedown', resizeContainer);
   findChild(consoleActions, 'close-button').addEventListener('click', closeContainer);
   consoleOuter.addEventListener('DOMNodeInserted', shiftConsoleActions);
+
+  REPLConsole.currentSession = this;
 };
 
 // Add CSS styles dynamically. This probably doesnt work for IE <8.
@@ -409,12 +411,13 @@ REPLConsole.installInto = function(id) {
   });
 
   replConsole.install(consoleElement);
-  REPLConsole.session[remotePath] = replConsole;
   return replConsole;
 };
 
-// Store instances with the remote paths
-REPLConsole.session = {};
+// This is to store the latest single session, and the stored session
+// is updated by the REPLConsole#install() method.
+// It allows to operate the current session from the other scripts.
+REPLConsole.currentSession = null;
 
 // DOM helpers
 function hasClass(el, className) {

--- a/lib/web_console/templates/error_page.js.erb
+++ b/lib/web_console/templates/error_page.js.erb
@@ -25,11 +25,7 @@ for (var i = 0; i < traceFrames.length; i++) {
 }
 
 function changeBinding(frameId, callback) {
-  var consoleElement = document.getElementById('console');
-  if (! consoleElement) { return; }
-  var remotePath = consoleElement.dataset.remotePath;
-  var session = REPLConsole.session[remotePath];
-  session.switchBindingTo(frameId, callback);
+  REPLConsole.currentSession.switchBindingTo(frameId, callback);
 }
 
 function changeSourceExtract(frameId) {


### PR DESCRIPTION
Make a change of `REPLConsole.session` to store only the latest single session, since the current way does not work properly after the console element is closed.