### PR TITLE
Require versioning in accept header

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -30,16 +30,10 @@ module WebConsole
       request = create_regular_or_whiny_request(env)
       return @app.call(env) unless request.from_whitelited_ip?
 
-      if request.xhr?
-        unless request.acceptable?
-          return respond_with_unacceptable_request
-        end
-      end
-
       if id = id_for_repl_session_update(request)
-        return update_repl_session(id, request.params)
+        return update_repl_session(id, request)
       elsif id = id_for_repl_session_stack_frame_change(request)
-        return change_stack_trace(id, request.params)
+        return change_stack_trace(id, request)
       end
 
       status, headers, body = @app.call(env)
@@ -62,6 +56,28 @@ module WebConsole
     end
 
     private
+
+      def json_response(opts = {})
+        status  = opts.fetch(:status, 200)
+        headers = { 'Content-Type' => 'application/json; charset = utf-8' }
+        body    = yield.to_json
+
+        Rack::Response.new(body, status, headers).finish
+      end
+
+      def json_response_with_session(id, request, opts = {})
+        json_response(opts) do
+          unless request.acceptable?
+            return respond_with_unacceptable_request
+          end
+
+          unless session = Session.find(id)
+            return respond_with_unavailable_session(id)
+          end
+
+          yield session
+        end
+      end
 
       def create_regular_or_whiny_request(env)
         request = Request.new(env)
@@ -88,46 +104,30 @@ module WebConsole
         end
       end
 
-      def update_repl_session(id, params)
-        unless session = Session.find(id)
-          return respond_with_unavailable_session(id)
+      def update_repl_session(id, request)
+        json_response_with_session(id, request) do |session|
+          { output: session.eval(request.params[:input]) }
         end
-
-        status  = 200
-        headers = { 'Content-Type' => 'application/json; charset = utf-8' }
-        body    = { output: session.eval(params[:input]) }.to_json
-
-        Rack::Response.new(body, status, headers).finish
       end
 
-      def change_stack_trace(id, params)
-        unless session = Session.find(id)
-          return respond_with_unavailable_session(id)
+      def change_stack_trace(id, request)
+        json_response_with_session(id, request) do |session|
+          session.switch_binding_to(request.params[:frame_id])
+
+          { ok: true }
         end
-
-        session.switch_binding_to(params[:frame_id])
-
-        status  = 200
-        headers = { 'Content-Type' => 'application/json; charset = utf-8' }
-        body    = { ok: true }.to_json
-
-        Rack::Response.new(body, status, headers).finish
       end
 
       def respond_with_unavailable_session(id)
-        status = 404
-        headers = { 'Content-Type' => 'application/json; charset = utf-8' }
-        body    = { output: format(UNAVAILABLE_SESSION_MESSAGE, id: id)}.to_json
-
-        Rack::Response.new(body, status, headers).finish
+        json_response(status: 404) do
+          { output: format(UNAVAILABLE_SESSION_MESSAGE, id: id)}
+        end
       end
 
       def respond_with_unacceptable_request
-        status  = 406
-        headers = { 'Content-Type' => 'application/json; charset = utf-8' }
-        body    = { error: UNACCEPTABLE_REQUEST_MESSAGE }.to_json
-
-        Rack::Response.new(body, status, headers).finish
+        json_response(status: 406) do
+          { error: UNACCEPTABLE_REQUEST_MESSAGE }
+        end
       end
   end
 end

--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -10,6 +10,9 @@ module WebConsole
     cattr_accessor :whitelisted_ips
     @@whitelisted_ips = Whitelist.new
 
+    # Define a vendor MIME type. We can call it using Mime::WEB_CONSOLE_V2 constant.
+    Mime::Type.register 'application/vnd.web-console.v2', :web_console_v2
+
     # Returns whether a request came from a whitelisted IP.
     #
     # For a request to hit Web Console features, it needs to come from a white
@@ -30,6 +33,11 @@ module WebConsole
     # render it as well.
     def acceptable_content_type?
       content_type.blank? || content_type.in?(acceptable_content_types)
+    end
+
+    # Returns whether the request is acceptable.
+    def acceptable?
+      xhr? && accepts.any? { |mime| Mime::WEB_CONSOLE_V2 == mime }
     end
 
     class GetSecureIp < ActionDispatch::RemoteIp::GetIp

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -476,6 +476,7 @@ function request(method, url, params, callback) {
   xhr.open(method, url, true);
   xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
   xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+  xhr.setRequestHeader("Accept", "<%= Mime::WEB_CONSOLE_V2 %>");
   xhr.send(params);
 
   xhr.onreadystatechange = function() {

--- a/test/templates/config.ru
+++ b/test/templates/config.ru
@@ -1,5 +1,7 @@
 require "action_view"
 require "pathname"
+require "action_dispatch"
+require "web_console"
 
 TEST_ROOT = Pathname(__FILE__).dirname
 

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -105,7 +105,21 @@ module WebConsole
       assert_equal(404, response.status)
     end
 
+    test "doesn't accept request for old version and reutrn 406" do
+      xhr :put, "/repl_sessions/no_such_session", { input: "__LINE__" },
+        {"HTTP_ACCEPT" => "application/vnd.web-console.v0"}
+
+      assert_equal(406, response.status)
+    end
+
     private
+
+      # Override the xhr testing helper of ActionDispatch to customize http headers
+      def xhr(*args)
+        args[3] ||= {}
+        args[3]['HTTP_ACCEPT'] ||= "#{Mime::WEB_CONSOLE_V2}"
+        super
+      end
 
       def raise_exception
         raise

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -73,10 +73,27 @@ module WebConsole
       assert_not req.acceptable_content_type?
     end
 
+    test '#acceptable? is truthy for current version' do
+      req = xhr('http://example.com', 'HTTP_ACCEPT' => "#{Mime::WEB_CONSOLE_V2}")
+
+      assert req.acceptable?
+    end
+
+    test '#acceptable? is falsy for request without vendor mime type' do
+      req = xhr('http://example.com', 'HTTP_ACCEPT' => 'text/plain; charset=utf-8')
+
+      assert_not req.acceptable?
+    end
+
     private
 
       def request(*args)
         Request.new(Rack::MockRequest.env_for(*args))
+      end
+
+      def xhr(*args)
+        args[1]['HTTP_X_REQUESTED_WITH'] ||= 'XMLHttpRequest'
+        request(*args)
       end
   end
 end


### PR DESCRIPTION
This is to require versioning in accept header from external tools.

* Add support for `Accept: application/vnd.web-console; version={required-version}`
* Return `406 Not Acceptable` if request is not acceptable

##### Example of Unacceptable Requests

Send unacceptable request to the test/dummy.

Request header:
```
GET / HTTP/1.1
Host: localhost:19292
User-Agent: curl/7.43.0
Accept: application/vnd.web-console.v0
```

Response header:
```
HTTP/1.1 406 Not Acceptable
Content-Type: application/json; charset = utf-8
Content-Length: 31
X-Request-Id: 07151b8b-1926-4e28-8720-1e4b7b81b36e
X-Runtime: 0.000465
Server: WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
Date: Fri, 26 Jun 2015 15:12:53 GMT
Connection: Keep-Alive
```

Response body:
```
{"error":"A supported version is expected in the Accept header."}
```