### PR TITLE
Add "X-Web-Console-Session-Id" to response headers

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -43,6 +43,7 @@ module WebConsole
       end
 
       if session && request.acceptable_content_type?
+        headers["X-Web-Console-Session-Id"] = session.id
         response = Rack::Response.new(body, status, headers)
         template = Template.new(env, session)
 

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -35,6 +35,14 @@ module WebConsole
       assert_select '#console'
     end
 
+    test 'returns X-Web-Console-Session-Id as response header' do
+      get '/', nil, 'CONTENT_TYPE' => 'text/html', 'web_console.binding' => binding
+
+      session_id = response.headers["X-Web-Console-Session-Id"]
+
+      assert_not Session.find(session_id).nil?
+    end
+
     test 'prioritizes web_console.exception over web_console.binding' do
       exception = raise_exception
 


### PR DESCRIPTION
This custom response header would be used by browser extensions.

* Add `X-Web-Console-Session-Id` to response headers
* Add tests for the custom header

Example of response headers:

```diff
  HTTP/1.1 500 Internal Server Error
  Content-Type: text/html; charset=utf-8
  Content-Length: 121277
+ X-Web-Console-Session-Id: 04251d0e07dd0ee018f8fe9ac3abf1a7
  X-Request-Id: d4af31ab-aeff-4063-990e-ef28f80ddefb
  X-Runtime: 0.102495
  Server: WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
  Date: Fri, 26 Jun 2015 17:05:36 GMT
  Connection: Keep-Alive
```