### PR TITLE
Require test_helper

### DIFF
--- a/test/web_console/whitelist_test.rb
+++ b/test/web_console/whitelist_test.rb
@@ -1,3 +1,5 @@
+require 'test_helper'
+
 module WebConsole
   class WhitelistTest < ActiveSupport::TestCase
     test 'localhost is always whitelisted' do


### PR DESCRIPTION
This fixes:

```
$ ruby -Itest test/web_console/whitelist_test.rb 
test/web_console/whitelist_test.rb:2:in `<module:WebConsole>': uninitialized constant WebConsole::ActiveSupport (NameError)
	from test/web_console/whitelist_test.rb:1:in `<main>'
```

and possibly some random test suite errors.