### PR TITLE
Extend REPLConsole.installInto() to accept argument options

### DIFF
--- a/lib/web_console/templates/_markup.html.erb
+++ b/lib/web_console/templates/_markup.html.erb
@@ -1,4 +1,4 @@
 <div id="console"
   data-remote-path='<%= "console/repl_sessions/#{@session.id}" %>'
-  data-initial-prompt='>> '>
+  data-prompt-label='>> '>
 </div>

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -54,9 +54,14 @@ var styleElementId = 'sr02459pvbvrmhco';
 
 // REPLConsole Constructor
 function REPLConsole(config) {
+  function getConfig(key, defaultValue) {
+    return config && config[key] || defaultValue;
+  }
+
   this.commandStorage = new CommandStorage();
-  this.prompt = config && config.promptLabel ? config.promptLabel : ' >>';
-  this.commandHandle = config && config.commandHandle ? config.commandHandle : function() { return this; }
+  this.prompt = getConfig('promptLabel', ' >>');
+  this.remotePath = getConfig('remotePath');
+  this.request = getConfig('request', this.request);
 }
 
 
@@ -140,7 +145,6 @@ REPLConsole.prototype.install = function(container) {
   this.outer = consoleOuter;
   this.inner = findChild(this.outer, 'console-inner');
   this.clipboard = findChild(container, 'clipboard');
-  this.remotePath = container.dataset.remotePath;
   this.newPromptBox();
   this.insertCss();
 
@@ -394,22 +398,16 @@ REPLConsole.prototype.switchBindingTo = function(frameId, callback) {
  * Install the console into the element with a specific ID.
  * Example: REPLConsole.installInto("target-id")
  */
-REPLConsole.installInto = function(id) {
+REPLConsole.installInto = function(id, options) {
   var consoleElement = document.getElementById(id);
-  var remotePath = consoleElement.dataset.remotePath;
-  var replConsole = new REPLConsole({
-    promptLabel: consoleElement.dataset.initialPrompt,
-    commandHandle: function(line) {
-      var _this = this;
-      var url = remotePath;
-      var params = "input=" + encodeURIComponent(line);
-      putRequest(url, params, function(xhr) {
-        var response = JSON.parse(xhr.responseText);
-        _this.writeOutput(response.output);
-      });
-    }
-  });
 
+  options = options || {};
+
+  for (var prop in consoleElement.dataset) {
+    options[prop] = options[prop] || consoleElement.dataset[prop];
+  }
+
+  var replConsole = new REPLConsole(options);
   replConsole.install(consoleElement);
   return replConsole;
 };

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -64,6 +64,28 @@ function REPLConsole(config) {
   this.request = getConfig('request', this.request);
 }
 
+REPLConsole.prototype.request = request;
+
+REPLConsole.prototype.getUrl = function(path) {
+  if (path) {
+    return this.remotePath + '/' + path;
+  } else {
+    return this.remotePath;
+  }
+};
+
+REPLConsole.prototype.commandHandle = function(line) {
+  var self = this;
+  var params = 'input=' + encodeURIComponent(line);
+
+  this.request('PUT', self.getUrl(), params, function(xhr) {
+    var response = JSON.parse(xhr.responseText);
+    self.writeOutput(response.output);
+  }, function(xhr) {
+    var response = JSON.parse(xhr.responseText);
+    self.writeError(response.output);
+  });
+};
 
 REPLConsole.prototype.install = function(container) {
   var _this = this;
@@ -267,6 +289,13 @@ REPLConsole.prototype.writeOutput = function(output) {
   consoleMessage.innerHTML = escapeHTML(output);
   this.inner.appendChild(consoleMessage);
   this.newPromptBox();
+  return consoleMessage;
+};
+
+REPLConsole.prototype.writeError = function(output) {
+  var consoleMessage = this.writeOutput(output);
+  addClass(consoleMessage, "error-message");
+  return consoleMessage;
 };
 
 REPLConsole.prototype.onEnterKey = function() {
@@ -468,7 +497,7 @@ function escapeHTML(html) {
 }
 
 // XHR helpers
-function request(method, url, params, callback) {
+function request(method, url, params, ok, fail) {
   var xhr = new XMLHttpRequest();
 
   xhr.open(method, url, true);
@@ -476,9 +505,21 @@ function request(method, url, params, callback) {
   xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
   xhr.send(params);
 
+  function isSuccess(status) {
+    return status >= 200 && status < 300 || status === 304;
+  }
+
+  // optional callbacks
+  ok   = ok || function() {};
+  fail = fail || function() {};
+
   xhr.onreadystatechange = function() {
     if (xhr.readyState === 4) {
-      callback(xhr);
+      if (isSuccess(xhr.status)) {
+        ok(xhr);
+      } else {
+        fail(xhr);
+      }
     }
   }
 }

--- a/lib/web_console/templates/style.css.erb
+++ b/lib/web_console/templates/style.css.erb
@@ -10,6 +10,7 @@
 .console .console-inner { font-family: monospace; font-size: 11px; width: 100%; height: 100%; overflow: none; background: #333; }
 .console .console-prompt-box { color: #FFF; }
 .console .console-message { color: #1AD027; margin: 0; border: 0; white-space: pre-wrap; background-color: #333; padding: 0; }
+.console .console-message.error-message { color: #fc9; }
 .console .console-focus .console-cursor { background: #FEFEFE; color: #333; font-weight: bold; }
 .console .resizer { background: #333; width: 100%; height: 4px; cursor: ns-resize; }
 .console .console-actions { padding-right: 3px; }

--- a/test/templates/spec/repl_console_spec.js
+++ b/test/templates/spec/repl_console_spec.js
@@ -1,6 +1,36 @@
 describe("REPLConsole", function() {
   SpecHelper.prepareStageElement();
 
+  describe(".installInto()", function() {
+    beforeEach(function() {
+      this.elm = document.createElement('div');
+      this.elm.innerHTML = '<div id="console" data-remote-path="data-remote-path" ' +
+        'data-prompt-label="data-prompt-label"></div>';
+      this.stageElement.appendChild(this.elm);
+    });
+
+    context("install console without options", function() {
+      beforeEach(function() {
+        this.console = REPLConsole.installInto('console');
+      });
+      it("should have data-prompt-label", function() {
+        assert.equal(this.console.prompt, 'data-prompt-label');
+      });
+      it("should have data-remote-path", function() {
+        assert.equal(this.console.remotePath, 'data-remote-path');
+      });
+    });
+
+    context("install console with {remotePath: 'opt-remote-path'}", function() {
+      beforeEach(function() {
+        this.console = REPLConsole.installInto('console', {remotePath: 'opt-remote-path'});
+      });
+      it("should have opt-remote-path", function() {
+        assert.equal(this.console.remotePath, 'opt-remote-path');
+      });
+    });
+  });
+
   describe("#install()", function() {
     beforeEach(function() {
       this.elm = document.createElement("div");


### PR DESCRIPTION
This pull request is mainly to change `REPLConsole.installInto()` to accept options via arguments, and it also contains the following changes:

* Use all `element.dataset.*` as the options of console if not set values
* Promote commandHandle as a method
  - Alternatively, provide `REPLConsole#request()` overridable-like method
* Rename `data-initial-prompt` => `data-prompt-label` on the console markup
* Add tests for REPLConsole.installInto()

In this pull request, I want to support the below case:

```javascript
// some sandbox-ed area (e.g., Chrome DevTools)
REPLConsole.installInto("console", {
  request: function(method, url, params, callback) {
    browser.api.sendMessage({
      type: "proxy-like-request",
      method: method,
      url: url,
      params: params
    }, function(xhrLikeObject) {
      callback(xhrLikeObject);
    })
  }
});
```

Thanks.