### PR TITLE
Change to use fixed mount point for the Web API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -161,6 +161,18 @@ end
 You may wanna check the [templates] folder at the source tree for the files you
 may override.
 
+### config.web_console.mount_point
+
+Usually the middleware of _Web Console_ is mounted at `/__web_console`.
+If you wanna change the path for some reasons, you can specify it
+by `config.web_console.mount_point`:
+
+```ruby
+Rails.application.configure do
+  config.web_console.mount_point = '/path/to/web_console'
+end
+```
+
 ## FAQ
 
 ### Where did /console go?

--- a/extensions/chrome/js/panel.js
+++ b/extensions/chrome/js/panel.js
@@ -23,7 +23,7 @@ port.onMessage.addListener(function(msg) {
 });
 
 function updateRemotePath(sessionId) {
-  var remotePath = 'console/repl_sessions/' + sessionId;
+  var remotePath = '__web_console/repl_sessions/' + sessionId;
   if (repl) {
     repl.remotePath = remotePath;
   } else {

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -43,6 +43,12 @@ module WebConsole
       app.middleware.insert_before ActionDispatch::DebugExceptions, Middleware
     end
 
+    initializer 'web_console.mount_point' do
+      if mount_point = config.web_console.mount_point
+        Middleware.mount_point = mount_point.chomp('/')
+      end
+    end
+
     initializer 'web_console.template_paths' do
       if template_paths = config.web_console.template_paths
         Template.template_paths.unshift(*Array(template_paths))

--- a/lib/web_console/template.rb
+++ b/lib/web_console/template.rb
@@ -38,6 +38,7 @@ module WebConsole
     def initialize(env, session)
       @env = env
       @session = session
+      @mount_point = Middleware.mount_point
     end
 
     # Render a template (inferred from +template_paths+) as a plain string.

--- a/lib/web_console/templates/_markup.html.erb
+++ b/lib/web_console/templates/_markup.html.erb
@@ -1,4 +1,4 @@
 <div id="console"
-  data-remote-path='<%= "console/repl_sessions/#{@session.id}" %>'
+  data-remote-path='<%= "#{@mount_point}/repl_sessions/#{@session.id}" %>'
   data-prompt-label='>> '>
 </div>

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -20,6 +20,7 @@ module WebConsole
     setup do
       Request.stubs(:whitelisted_ips).returns(IPAddr.new('0.0.0.0/0'))
 
+      Middleware.mount_point = ''
       @app = Middleware.new(Application.new)
     end
 
@@ -99,6 +100,15 @@ module WebConsole
       xhr :post, "/repl_sessions/#{session.id}/trace", { frame_id: 1 }
 
       assert_equal({ ok: true }.to_json, response.body)
+    end
+
+    test 'can be changed mount point' do
+      Middleware.mount_point = '/customized/path'
+
+      session, line = Session.new(binding), __LINE__
+      xhr :put, "/customized/path/repl_sessions/#{session.id}", { input: '__LINE__' }
+
+      assert_equal({ output: "=> #{line}\n" }.to_json, response.body)
     end
 
     test 'unavailable sessions respond to the user with a message' do

--- a/test/web_console/railtie_test.rb
+++ b/test/web_console/railtie_test.rb
@@ -40,6 +40,15 @@ module WebConsole
       end
     end
 
+    test 'config.mount_point changes the mount point of Middleware' do
+      new_uninitialized_app do |app|
+        app.config.web_console.mount_point = '/customized/path'
+        app.initialize!
+
+        assert_equal Middleware.mount_point, '/customized/path'
+      end
+    end
+
     test 'config.whiny_request removes extra logging' do
       new_uninitialized_app do |app|
         app.config.web_console.whiny_requests = false


### PR DESCRIPTION
This change is to simplify the routing options of WebConsole::Middleware class.

* Add options[:mount] as a customizable mount point of Web Console
  - (but it makes `/repl_sessions/...` hard-coded routes)

```
# routes
/__web_console <- configurable
  |-> /repl_sessions/<id>
  --> /repl_sessions/<id>/trace
```

##### Other Sketches of the Mount Point

It supposes that the `REPLConsole` class will have the Mount Point and the Session ID in JavaScript, and the class will come to generate the URL of requests by itself (not using remote path attribute).

```diff
# Sketch of "_markup.html.erb"
 <div id="console"
-   data-remote-path='<%= "console/repl_sessions/#{@session.id}" %>'
+   data-mount-point='<%= @mount_point %>'
+   data-session-id='<%= @session.id %>'
    data-prompt-label='>> '>
 </div>
```

However, my concern is how to detect the customized routes from the browser extensions, since they need to use pre-compiled code, and so they can't embed the Middleware's options. As a solution, I'm thinking to add a custom header like the Session ID.

```diff
 # Sketch of a custom header for customized mount point
 HTTP/1.1 500 Internal Server Error
 Content-Type: text/html; charset=utf-8
 Content-Length: xxx
 X-Web-Console-Session-Id: awesome-session-id
+X-Web-Console-Mount-Point: /cutomized-path
```

```js
// pseudo code
var opts = { sessionId: headers.sessionId, mountPoint: headers.mountPoint };
var repl = REPLConsole.installInto('console', opts);
repl.sessionId = otherSessionId;
```

* * * 

Thank you!