### PR TITLE
Update for i18n supports

### DIFF
--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -5,10 +5,13 @@ require 'json'
 require 'web_console/whitelist'
 require 'web_console/request'
 require 'web_console/view'
+require 'web_console/testing/helper'
 
 module WebConsole
   module Testing
     class FakeMiddleware
+      I18n.load_path.concat(Dir[Helper.gem_root.join('lib/web_console/locales/*.yml')])
+
       DEFAULT_HEADERS = { "Content-Type" => "application/javascript" }
 
       def initialize(opts)

--- a/lib/web_console/view.rb
+++ b/lib/web_console/view.rb
@@ -25,9 +25,13 @@ module WebConsole
       render(template: template, layout: 'layouts/inlined_string')
     end
 
-    # Escaped alias for "ActionView::Helpers::TranslationHelper.t".
+    # Override method for ActionView::Helpers::TranslationHelper#t.
+    #
+    # This method escapes the original return value for JavaScript, since the
+    # method returns a HTML tag with some attributes when the key is not found,
+    # so it could cause a syntax error if we use the value in the string literals.
     def t(key, options = {})
-      super.gsub("\n", "\\n")
+      j super
     end
   end
 end


### PR DESCRIPTION
This pull request contains some update for i18n:

* Set locales on Testing::FakeMiddleware
* Use j() for i18n translating text
