### PR TITLE
Add X-Web-Console-Mount-Point

### DIFF
--- a/extensions/chrome/js/panel.js
+++ b/extensions/chrome/js/panel.js
@@ -15,19 +15,20 @@ REPLConsole.request = function(method, url, params, callback) {
 
 // Handle messages from the background script.
 port.onMessage.addListener(function(msg) {
-  if (msg.type === 'session-id') {
-    updateRemotePath(msg.sessionId);
+  if (msg.type === 'update-session') {
+    updateSession(msg);
   } else if (msg.type === 'remove-console') {
     removeConsole();
   }
 });
 
-function updateRemotePath(sessionId) {
-  var remotePath = '__web_console/repl_sessions/' + sessionId;
+function updateSession(info) {
   if (repl) {
-    repl.remotePath = remotePath;
+    repl.sessionId  = info.sessionId;
+    repl.mountPoint = info.mountPoint;
   } else {
-    repl = REPLConsole.installInto('console', { remotePath: remotePath });
+    var options = { sessionId: info.sessionId, mountPoint: info.mountPoint };
+    repl = REPLConsole.installInto('console', options);
   }
 }
 
@@ -36,5 +37,5 @@ function removeConsole() {
   chrome.devtools.inspectedWindow.eval(script);
 }
 
-port.postMessage({ type: 'session-id', tabId: tabId });
+port.postMessage({ type: 'session', tabId: tabId });
 removeConsole();

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -41,6 +41,7 @@ module WebConsole
         template = Template.new(env, session)
 
         response.headers["X-Web-Console-Session-Id"] = session.id
+        response.headers["X-Web-Console-Mount-Point"] = mount_point
         response.write(template.render('index'))
         response.finish
       else

--- a/lib/web_console/templates/_markup.html.erb
+++ b/lib/web_console/templates/_markup.html.erb
@@ -1,4 +1,5 @@
 <div id="console"
-  data-remote-path='<%= "#{@mount_point}/repl_sessions/#{@session.id}" %>'
+  data-mount-point='<%= @mount_point %>'
+  data-session-id='<%= @session.id %>'
   data-prompt-label='>> '>
 </div>

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -60,15 +60,17 @@ function REPLConsole(config) {
 
   this.commandStorage = new CommandStorage();
   this.prompt = getConfig('promptLabel', ' >>');
-  this.remotePath = getConfig('remotePath');
+  this.mountPoint = getConfig('mountPoint');
+  this.sessionId = getConfig('sessionId');
 }
 
-REPLConsole.prototype.getUrl = function(path) {
+REPLConsole.prototype.getSessionUrl = function(path) {
+  var parts = [ this.mountPoint, 'repl_sessions', this.sessionId ];
   if (path) {
-    return this.remotePath + '/' + path;
-  } else {
-    return this.remotePath;
+    parts.push(path);
   }
+  // Join and remove duplicate slashes.
+  return parts.join('/').replace(/([^:]\/)\/+/g, '$1');
 };
 
 REPLConsole.prototype.commandHandle = function(line, callback) {
@@ -96,7 +98,7 @@ REPLConsole.prototype.commandHandle = function(line, callback) {
     }
   }
 
-  putRequest(self.getUrl(), params, function(xhr) {
+  putRequest(self.getSessionUrl(), params, function(xhr) {
     var response = parseJSON(xhr.responseText);
     var result   = isSuccess(xhr.status);
     if (result) {
@@ -448,7 +450,7 @@ REPLConsole.prototype.scrollToBottom = function() {
 
 // Change the binding of the console
 REPLConsole.prototype.switchBindingTo = function(frameId, callback) {
-  var url = this.remotePath + "/trace";
+  var url = this.getSessionUrl('trace');
   var params = "frame_id=" + encodeURIComponent(frameId);
   postRequest(url, params, callback);
 };

--- a/test/templates/config.ru
+++ b/test/templates/config.ru
@@ -34,13 +34,13 @@ map "/templates" do
   )
 end
 
-map "/mock/repl/result" do
+map "/mock/repl_sessions/result" do
   headers = { 'Content-Type' => 'application/json' }
   body = [ { output: '=> "fake-result"\n' }.to_json ]
   run lambda { |env| [ 200, headers, body ] }
 end
 
-map "/mock/repl/error" do
+map "/mock/repl_sessions/error" do
   headers = { 'Content-Type' => 'application/json' }
   body = [ { output: 'fake-error-message' }.to_json ]
   run lambda { |env| [ 400, headers, body ] }

--- a/test/templates/spec/repl_console_spec.js
+++ b/test/templates/spec/repl_console_spec.js
@@ -1,23 +1,26 @@
 describe("REPLConsole", function() {
   SpecHelper.prepareStageElement();
 
-  describe("#commandHandle()", function() {
+  describe("#commandHandle", function() {
+    function runCommandHandle(self, consoleOptions, callback) {
+      self.console = REPLConsole.installInto('console', consoleOptions);
+      self.console.commandHandle('fake-input', function(result, response) {
+        self.result   = result;
+        self.response = response;
+        self.message  = self.elm.getElementsByClassName('console-message')[0];
+        callback();
+      });
+    }
+
     beforeEach(function() {
       this.elm = document.createElement('div');
       this.elm.innerHTML = '<div id="console"></div>';
       this.stageElement.appendChild(this.elm);
     });
 
-    context("remotePath: /mock/repl/result", function() {
+    context("sessionId=result", function() {
       beforeEach(function(done) {
-        var self = this;
-        self.console = REPLConsole.installInto('console', { remotePath: '/mock/repl/result' });
-        self.console.commandHandle('fake-input', function(result, response) {
-          self.result   = result;
-          self.response = response;
-          self.message  = self.elm.getElementsByClassName('console-message')[0];
-          done();
-        });
+        runCommandHandle(this, { mountPoint: '/mock', sessionId: 'result' }, done);
       });
       it("should be a successful request", function() {
         assert.ok(this.result);
@@ -30,16 +33,9 @@ describe("REPLConsole", function() {
       });
     });
 
-    context("remotePath: /mock/repl/error", function() {
+    context("sessionId=error", function() {
       beforeEach(function(done) {
-        var self = this;
-        self.console = REPLConsole.installInto('console', { remotePath: '/mock/repl/error' });
-        self.console.commandHandle('fake-input', function(result, response) {
-          self.result   = result;
-          self.response = response;
-          self.message  = self.elm.getElementsByClassName('console-message')[0];
-          done();
-        });
+        runCommandHandle(this, { mountPoint: '/mock', sessionId: 'error' }, done);
       });
       it("should not be a successful request", function() {
         assert.notOk(this.result);
@@ -52,15 +48,9 @@ describe("REPLConsole", function() {
       });
     });
 
-    context("remotePath: /mock/repl_sessions/error.txt", function() {
+    context("sessionId=error.txt", function() {
       beforeEach(function(done) {
-        var self = this;
-        var options = { remotePath: '/mock/repl_sessions/error.txt' };
-        self.console = REPLConsole.installInto('console', options);
-        self.console.commandHandle('fake-input', function(result, response) {
-          self.message = self.elm.getElementsByClassName('console-message')[0];
-          done();
-        });
+        runCommandHandle(this, { mountPoint: '/mock', sessionId: 'error.txt' }, done);
       });
       it("should output HTTP status code", function() {
         assert.match(this.message.innerHTML, /400 Bad Request/);
@@ -68,11 +58,12 @@ describe("REPLConsole", function() {
     });
   });
 
-  describe(".installInto()", function() {
+  describe(".installInto", function() {
     beforeEach(function() {
       this.elm = document.createElement('div');
-      this.elm.innerHTML = '<div id="console" data-remote-path="data-remote-path" ' +
-        'data-prompt-label="data-prompt-label"></div>';
+      this.elm.innerHTML = '<div id="console" data-mount-point="attr-mount-point" ' +
+        'data-session-id="attr-session-id" ' +
+        'data-prompt-label="attr-prompt-label"></div>';
       this.stageElement.appendChild(this.elm);
     });
 
@@ -80,25 +71,32 @@ describe("REPLConsole", function() {
       beforeEach(function() {
         this.console = REPLConsole.installInto('console');
       });
-      it("should have data-prompt-label", function() {
-        assert.equal(this.console.prompt, 'data-prompt-label');
+      it("should have attr-prompt-label", function() {
+        assert.equal(this.console.prompt, 'attr-prompt-label');
       });
-      it("should have data-remote-path", function() {
-        assert.equal(this.console.remotePath, 'data-remote-path');
+      it("should have attr-mount-point", function() {
+        assert.equal(this.console.mountPoint, 'attr-mount-point');
+      });
+      it("should have attr-session-id", function() {
+        assert.equal(this.console.sessionId, 'attr-session-id');
       });
     });
 
-    context("install console with {remotePath: 'opt-remote-path'}", function() {
+    context("install console with options", function() {
       beforeEach(function() {
-        this.console = REPLConsole.installInto('console', {remotePath: 'opt-remote-path'});
+        var options = { mountPoint: 'opt-mount-point', sessionId: 'opt-session-id' };
+        this.console = REPLConsole.installInto('console', options);
       });
-      it("should have opt-remote-path", function() {
-        assert.equal(this.console.remotePath, 'opt-remote-path');
+      it("should have opt-mount-point", function() {
+        assert.equal(this.console.mountPoint, 'opt-mount-point');
+      });
+      it("should have opt-session-id", function() {
+        assert.equal(this.console.sessionId, 'opt-session-id');
       });
     });
   });
 
-  describe("#install()", function() {
+  describe("#install", function() {
     beforeEach(function() {
       this.elm = document.createElement("div");
       this.stageElement.appendChild(this.elm);


### PR DESCRIPTION
It returns the mount point of the Middleware.

And, in order to support it, this pull request contains the below changes:

* Update JavaScript and Chrome Extension to use the mount point instead of the remote path
* Update tests for JavaScript
  - Use the mount point
  - Unify `/mock/repl*/*` into `/mock/repl_sessions/*`

Thanks.