### PR TITLE
Update for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
   - 2.2
   - ruby-head
   - rbx-2
   - jruby
 
 gemfile:
-  - gemfiles/Gemfile-4-0-stable
-  - gemfiles/Gemfile-4-1-stable
-  - gemfiles/Gemfile-4-2-stable
   - Gemfile
 
 env:
@@ -32,7 +26,7 @@ matrix:
   include:
     - gemfile: gemfiles/Gemfile-4-0-stable
       env: TEST_SUITE=test:templates
-      rvm: 1.9.3
+      rvm: 2.2.2
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 gem 'rails', github: 'rails/rails'
 gem 'arel', github: 'rails/arel'
+gem 'sprockets', github: 'rails/sprockets'
+gem 'sprockets-rails', github: 'rails/sprockets-rails'
+gem 'rack', github: 'rack/rack'
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/lib/web_console/extensions.rb
+++ b/lib/web_console/extensions.rb
@@ -1,16 +1,17 @@
 ActionDispatch::DebugExceptions.class_eval do
-  def render_exception_with_web_console(env, exception)
-    render_exception_without_web_console(env, exception).tap do
-      error = ActionDispatch::ExceptionWrapper.new(env, exception).exception
+  def render_exception_with_web_console(request, exception)
+    render_exception_without_web_console(request, exception).tap do
+      backtrace_cleaner = request.env['action_dispatch.backtrace_cleaner']
+      error = ActionDispatch::ExceptionWrapper.new(backtrace_cleaner, exception).exception
 
       # Get the original exception if ExceptionWrapper decides to follow it.
-      env['web_console.exception'] = error
+      request.env['web_console.exception'] = error
 
       # ActionView::Template::Error bypass ExceptionWrapper original
       # exception following. The backtrace in the view is generated from
       # reaching out to original_exception in the view.
       if error.is_a?(ActionView::Template::Error)
-        env['web_console.exception'] = error.original_exception
+        request.env['web_console.exception'] = error.original_exception
       end
     end
   end

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,3 +1,3 @@
 module WebConsole
-  VERSION = '2.2.1'
+  VERSION = '3.0.0'
 end

--- a/test/web_console/extensions_test.rb
+++ b/test/web_console/extensions_test.rb
@@ -16,7 +16,7 @@ module ActionDispatch
     end
 
     test "follows ActionView::Template::Error original error in env['web_console.exception']" do
-      get "/", {}, {
+      get "/", params: {}, headers: {
         'action_dispatch.show_detailed_exceptions' => true,
         'action_dispatch.show_exceptions' => true,
         'action_dispatch.logger' => Logger.new(StringIO.new)

--- a/test/web_console/helper_test.rb
+++ b/test/web_console/helper_test.rb
@@ -65,7 +65,7 @@ module WebConsole
     end
 
     test 'renders a console into a view' do
-      get '/', nil, 'CONTENT_TYPE' => 'text/html'
+      get '/', params: nil, headers: { 'CONTENT_TYPE' => 'text/html' }
 
       assert_select '#console'
     end
@@ -74,12 +74,12 @@ module WebConsole
       @app = Middleware.new(MultipleConsolesApplication.new)
 
       assert_raises(DoubleRenderError) do
-        get '/', nil, 'CONTENT_TYPE' => 'text/html'
+        get '/', params: nil, headers: { 'CONTENT_TYPE' => 'text/html' }
       end
     end
 
     test "doesn't hijack current view" do
-      get '/', nil, 'CONTENT_TYPE' => 'text/html'
+      get '/', params: nil, headers: { 'CONTENT_TYPE' => 'text/html' }
 
       assert_select '#hello-world'
       assert_select '#console'

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -43,33 +43,33 @@ module WebConsole
     end
 
     test 'render console in an html application from web_console.binding' do
-      get '/', nil, 'web_console.binding' => binding
+      get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       assert_select '#console'
     end
 
     test 'render console in an html application from web_console.exception' do
-      get '/', nil, 'web_console.exception' => raise_exception
+      get '/', params: nil, headers: { 'web_console.exception' => raise_exception }
 
       assert_select 'body > #console'
     end
 
     test 'render console if response format is HTML' do
       @app = Middleware.new(Application.new(response_content_type: Mime::HTML))
-      get '/', nil, 'web_console.binding' => binding
+      get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       assert_select '#console'
     end
 
     test 'does not render console if response format is not HTML' do
       @app = Middleware.new(Application.new(response_content_type: Mime::JSON))
-      get '/', nil, 'web_console.binding' => binding
+      get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       assert_select '#console', 0
     end
 
     test 'returns X-Web-Console-Session-Id as response header' do
-      get '/', nil, 'web_console.binding' => binding
+      get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       session_id = response.headers["X-Web-Console-Session-Id"]
 
@@ -81,12 +81,12 @@ module WebConsole
 
       Session.expects(:from_exception).with(exception)
 
-      get '/', nil, 'web_console.binding' => binding, 'web_console.exception' => exception
+      get '/', params: nil, headers: { 'web_console.binding' => binding, 'web_console.exception' => exception }
     end
 
     test "doesn't render console in non html response" do
       @app = Middleware.new(Application.new(response_content_type: Mime::JSON))
-      get '/', nil, 'web_console.binding' => binding
+      get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       assert_select '#console', 0
     end
@@ -95,14 +95,14 @@ module WebConsole
       Request.stubs(:whitelisted_ips).returns(IPAddr.new('127.0.0.1'))
 
       silence(:stderr) do
-        get '/', nil, 'REMOTE_ADDR' => '1.1.1.1', 'web_console.binding' => binding
+        get '/', params: nil, headers: { 'REMOTE_ADDR' => '1.1.1.1', 'web_console.binding' => binding }
       end
 
       assert_select '#console', 0
     end
 
     test "doesn't render console without a web_console.binding or web_console.exception" do
-      get '/', nil
+      get '/', params: nil
 
       assert_select '#console', 0
     end
@@ -112,8 +112,8 @@ module WebConsole
 
       Session.stubs(:from_binding).returns(session)
 
-      get '/', nil, 'web-console.binding' => binding
-      xhr :put, "/repl_sessions/#{session.id}", { input: '__LINE__' }
+      get '/', params: nil, headers: { 'web-console.binding' => binding }
+      put "/repl_sessions/#{session.id}", xhr: true, params: { input: '__LINE__' }
 
       assert_equal({ output: "=> #{line}\n" }.to_json, response.body)
     end
@@ -123,8 +123,8 @@ module WebConsole
 
       Session.stubs(:from_exception).returns(session)
 
-      get '/', nil, 'web-console.exception' => exception
-      xhr :post, "/repl_sessions/#{session.id}/trace", { frame_id: 1 }
+      get '/', params: nil, headers: { 'web-console.exception' => exception }
+      post "/repl_sessions/#{session.id}/trace", xhr: true, params: { frame_id: 1 }
 
       assert_equal({ ok: true }.to_json, response.body)
     end
@@ -133,37 +133,47 @@ module WebConsole
       Middleware.mount_point = '/customized/path'
 
       session, line = Session.new(binding), __LINE__
-      xhr :put, "/customized/path/repl_sessions/#{session.id}", { input: '__LINE__' }
+      put "/customized/path/repl_sessions/#{session.id}", params: { input: '__LINE__' }, xhr: true
 
       assert_equal({ output: "=> #{line}\n" }.to_json, response.body)
     end
 
     test 'unavailable sessions respond to the user with a message' do
-      xhr :put, '/repl_sessions/no_such_session', { input: '__LINE__' }
+      put '/repl_sessions/no_such_session', xhr: true, params: { input: '__LINE__' }
 
       assert_equal(404, response.status)
     end
 
     test 'unavailable sessions can occur on binding switch' do
-      xhr :post, "/repl_sessions/no_such_session/trace", { frame_id: 1 }
+      post "/repl_sessions/no_such_session/trace", xhr: true, params: { frame_id: 1 }
 
       assert_equal(404, response.status)
     end
 
     test "doesn't accept request for old version and reutrn 406" do
-      xhr :put, "/repl_sessions/no_such_session", { input: "__LINE__" },
-        {"HTTP_ACCEPT" => "application/vnd.web-console.v0"}
+      put "/repl_sessions/no_such_session", xhr: true, params: { input: "__LINE__" },
+        headers: {"HTTP_ACCEPT" => "application/vnd.web-console.v0"}
 
       assert_equal(406, response.status)
     end
 
     private
 
-      # Override the xhr testing helper of ActionDispatch to customize http headers
-      def xhr(*args)
-        args[3] ||= {}
-        args[3]['HTTP_ACCEPT'] ||= "#{Mime::WEB_CONSOLE_V2}"
+      # Override the put and post testing helper of ActionDispatch to customize http headers
+      def put(http_method, path, *args)
+        update_path_args(path)
         super
+      end
+
+      def post(http_method, path, *args)
+        update_path_args(path)
+        super
+      end
+
+      def update_path_args(path)
+        unless path[:headers]
+          path.merge!(headers: { 'HTTP_ACCEPT' => Mime::WEB_CONSOLE_V2 })
+        end
       end
 
       def raise_exception

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -150,7 +150,7 @@ module WebConsole
       assert_equal(404, response.status)
     end
 
-    test "doesn't accept request for old version and reutrn 406" do
+    test "doesn't accept request for old version and return 406" do
       put "/repl_sessions/no_such_session", xhr: true, params: { input: "__LINE__" },
         headers: {"HTTP_ACCEPT" => "application/vnd.web-console.v0"}
 

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.files      = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown", "CHANGELOG.markdown"]
 
+  s.required_ruby_version = '>= 2.2.2'
+
   rails_version = ">= 4.0"
 
   s.add_dependency "railties",          rails_version


### PR DESCRIPTION
This updates web console so it can work with Rails 5. Changes include:

* Setting default Ruby version to 2.2.2 (required by Rails 5)
* Setting github repos for sprockets, sprockets-rails, rack
* Fixing kwargs arguments and deprecation warnings
* Fixing the method signature for the ExceptionWrapper since it changed in Rails and doesn't properly show the exception when on Rails 5
* Bumping the web console version (I wasn't sure about this but it's a breaking change so I bumped it. Let me know if you want it changed back or to something else).