### PR TITLE
Revamped integrations for CRuby and Rubinius

### DIFF
--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -1,5 +1,3 @@
-require 'binding_of_caller'
-
 require 'active_support/lazy_load_hooks'
 require 'active_support/logger'
 

--- a/lib/web_console/helper.rb
+++ b/lib/web_console/helper.rb
@@ -11,7 +11,7 @@ module WebConsole
     def console(binding = nil)
       raise DoubleRenderError if request.env['web_console.binding']
 
-      request.env['web_console.binding'] = binding || ::Kernel.binding.of_caller(1)
+      request.env['web_console.binding'] = binding || ::WebConsole.caller_bindings.first
 
       # Make sure nothing is rendered from the view helper. Otherwise
       # you're gonna see unexpected #<Binding:0x007fee4302b078> in the

--- a/lib/web_console/integration.rb
+++ b/lib/web_console/integration.rb
@@ -1,3 +1,28 @@
+module WebConsole
+  # Returns the Ruby bindings of Kernel#callers locations.
+  #
+  # The list of bindings here doesn't map 1 to 1 with Kernel#callers, as we
+  # can't build Ruby bindings for C functions or the equivalent native
+  # implementations in JRuby and Rubinius.
+  #
+  # This method needs to be overridden by every integration.
+  def self.caller_bindings
+    raise NotImplementedError
+  end
+end
+
+class Exception
+  # Returns an array of the exception backtrace locations bindings.
+  #
+  # The list won't map to the traces in #backtrace 1 to 1, because we can't
+  # build bindings for every trace (C functions, for example).
+  #
+  # Every integration should the instance variable.
+  def bindings
+    @bindings || []
+  end
+end
+
 case RUBY_ENGINE
 when 'rbx'
   require 'web_console/integration/rubinius'

--- a/lib/web_console/integration/cruby.rb
+++ b/lib/web_console/integration/cruby.rb
@@ -1,40 +1,23 @@
-class Exception
-  begin
-    # We share the same exception binding extraction mechanism as better_errors,
-    # so try to use it if it is already available. It also solves problems like
-    # charliesome/better_errors#272, caused by an infinite recursion.
-    require 'better_errors'
+require 'debug_inspector'
 
-    # The bindings in which the exception originated in.
-    def bindings
-      @bindings || __better_errors_bindings_stack
-    end
-  rescue LoadError
-    # The bindings in which the exception originated in.
-    def bindings
-      @bindings || []
-    end
+def WebConsole.caller_bindings
+  bindings = RubyVM::DebugInspector.open do |context|
+    context.backtrace_locations.each_index.map { |i| context.frame_binding(i) }
+  end
 
-    # CRuby calls #set_backtrace every time it raises an exception. Overriding
-    # it to assign the #bindings.
-    def set_backtrace_with_binding_of_caller(*args)
-      # Thanks to @charliesome who wrote this bit for better_errors.
-      unless Thread.current[:__web_console_exception_lock]
-        Thread.current[:__web_console_exception_lock] = true
-        begin
-          # Raising an exception here will cause all of the rubies to go into a
-          # stack overflow. Some rubies may even segfault. See
-          # https://bugs.ruby-lang.org/issues/10164 for details.
-          @bindings = binding.callers.drop(1)
-        ensure
-          Thread.current[:__web_console_exception_lock] = false
-        end
-      end
+  # For C functions, we can't extract a binding. In this case,
+  # DebugInspector#frame_binding would have returned us nil. That's why we need
+  # to compact the bindings.
+  #
+  # Dropping two bindings, removes the current Ruby one in this exact method,
+  # and the one in the caller method. The caller method binding can be obtained
+  # by Kernel#binding, if needed.
+  bindings.compact.drop(2)
+end
 
-      set_backtrace_without_binding_of_caller(*args)
-    end
-
-    alias_method :set_backtrace_without_binding_of_caller, :set_backtrace
-    alias_method :set_backtrace, :set_backtrace_with_binding_of_caller
+TracePoint.trace(:raise) do |context|
+  exc = context.raised_exception
+  if exc.bindings.empty?
+    exc.instance_variable_set(:@bindings, WebConsole.caller_bindings)
   end
 end

--- a/lib/web_console/integration/rubinius.rb
+++ b/lib/web_console/integration/rubinius.rb
@@ -1,62 +1,34 @@
-module WebConsole
-  module Rubinius
-    # Filters internal Rubinius locations.
-    #
-    # There are a couple of reasons why we wanna filter out the locations.
-    #
-    # * ::Kernel.raise, is implemented in Ruby for Rubinius. We don't wanna
-    #   have the frame for it to align with the CRuby and JRuby implementations.
-    #
-    # * For internal methods location variables can be nil. We can't create a
-    #   bindings for them.
-    #
-    # * Bindings from the current file are considered internal and ignored.
-    #
-    # We do that all that so we can align the bindings with the backtraces
-    # entries.
-    class InternalLocationFilter
-      def initialize(locations)
-        @locations = locations
-      end
+def WebConsole.caller_bindings
+  locations = ::Rubinius::VM.backtrace(1, true)
 
-      def filter
-        @locations.reject do |location|
-          location.file.start_with?('kernel/delta/kernel.rb') ||
-            location.file == __FILE__ ||
-            location.variables.nil?
-        end
-      end
-    end
-
-    # Gets the current bindings for all available Ruby frames.
-    #
-    # Filters the internal Rubinius and WebConsole frames.
-    def self.current_bindings
-      locations = ::Rubinius::VM.backtrace(1, true)
-
-      InternalLocationFilter.new(locations).filter.map do |location|
-        Binding.setup(
-          location.variables,
-          location.variables.method,
-          location.constant_scope,
-          location.variables.self,
-          location
-        )
-      end
-    end
+  # Kernel.raise, is implemented in Ruby for Rubinius. We don't wanna have
+  # the frame for it to align with the CRuby and JRuby implementations.
+  #
+  # For internal methods location variables can be nil. We can't create a
+  # bindings for them.
+  locations.reject! do |location|
+    location.file.start_with?('kernel/delta/kernel.rb') || location.variables.nil?
   end
-end
 
-::Exception.class_eval do
-  def bindings
-    @bindings || []
+  bindings = locations.map do |location|
+    Binding.setup(
+      location.variables,
+      location.variables.method,
+      location.constant_scope,
+      location.variables.self,
+      location
+    )
   end
+
+  # Drop the binding of the direct caller. That one can be created by
+  # Kernel#binding.
+  bindings.drop(1)
 end
 
 ::Rubinius.singleton_class.class_eval do
   def raise_exception_with_current_bindings(exc)
     if exc.bindings.empty?
-      exc.instance_variable_set(:@bindings, WebConsole::Rubinius.current_bindings)
+      exc.instance_variable_set(:@bindings, WebConsole.caller_bindings)
     end
 
     raise_exception_without_current_bindings(exc)

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
 
   rails_version = ">= 4.0"
 
-  s.add_dependency "railties",          rails_version
-  s.add_dependency "activemodel",       rails_version
-  s.add_dependency "sprockets-rails",   ">= 2.0", "< 4.0"
-  s.add_dependency "binding_of_caller", ">= 0.7.2"
+  s.add_dependency "railties",        rails_version
+  s.add_dependency "activemodel",     rails_version
+  s.add_dependency "sprockets-rails", ">= 2.0", "< 4.0"
+  s.add_dependency "debug_inspector"
 
   # We need those for the testing application to run.
   s.add_development_dependency "actionmailer", rails_version


### PR DESCRIPTION
With support for Ruby 2.2.2 and above, we can get the CRuby integration running only by exposing the debug inspector API to Ruby land and using the builtin tracepoint API. This replaces `binding_of_caller` for the way lighter gem of `debug_inspector`.

While redoing the CRuby integration, I have extracted a new common interface for every integration to implement. That's `WebConsole.caller_bindings` and a single definition of `Exception#bindings`. The rubinius integration has also been changed here, as it didn't needed much work to support the new scheme.

This leaves us with the JRuby integration hanging at the moment, because I can't even start the dummy application with Rails 5 with JRuby 9.0.{0,1}.0 at the moment. I can't target 1.7 series, because of the kwargs params usage we have. I know we don't officially support it, but I like JRuby and will try to get the integration running as soon as we get 5 somehow working on it.