### PR TITLE
Don't reference deprecated Mime::CONTENT_TYPES

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -48,7 +48,7 @@ module WebConsole
     private
 
       def acceptable_content_type?(headers)
-        Mime::Type.parse(headers['Content-Type']).first == Mime::HTML
+        Mime::Type.parse(headers['Content-Type']).first == Mime[:html]
       end
 
       def json_response(opts = {})

--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -5,7 +5,7 @@ module WebConsole
     cattr_accessor :whitelisted_ips
     @@whitelisted_ips = Whitelist.new
 
-    # Define a vendor MIME type. We can call it using Mime::WEB_CONSOLE_V2 constant.
+    # Define a vendor MIME type. We can call it using Mime[:web_console_v2].
     Mime::Type.register 'application/vnd.web-console.v2', :web_console_v2
 
     # Returns whether a request came from a whitelisted IP.
@@ -23,7 +23,7 @@ module WebConsole
 
     # Returns whether the request is acceptable.
     def acceptable?
-      xhr? && accepts.any? { |mime| Mime::WEB_CONSOLE_V2 == mime }
+      xhr? && accepts.any? { |mime| Mime[:web_console_v2] == mime }
     end
 
     private

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -488,7 +488,7 @@ REPLConsole.request = function request(method, url, params, callback) {
   xhr.open(method, url, true);
   xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
   xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-  xhr.setRequestHeader("Accept", "<%= Mime::WEB_CONSOLE_V2 %>");
+  xhr.setRequestHeader("Accept", "<%= Mime[:web_console_v2] %>");
   xhr.send(params);
 
   xhr.onreadystatechange = function() {

--- a/test/web_console/helper_test.rb
+++ b/test/web_console/helper_test.rb
@@ -20,7 +20,7 @@ module WebConsole
         end
 
         def headers
-          { 'Content-Type' => "#{Mime::HTML}; charset=utf-8" }
+          { 'Content-Type' => "#{Mime[:html]}; charset=utf-8" }
         end
 
         def body

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -4,7 +4,7 @@ module WebConsole
   class MiddlewareTest < ActionDispatch::IntegrationTest
     class Application
       def initialize(options = {})
-        @response_content_type = options[:response_content_type] || Mime::HTML
+        @response_content_type = options[:response_content_type] || Mime[:html]
       end
 
       def call(env)
@@ -55,14 +55,14 @@ module WebConsole
     end
 
     test 'render console if response format is HTML' do
-      @app = Middleware.new(Application.new(response_content_type: Mime::HTML))
+      @app = Middleware.new(Application.new(response_content_type: Mime[:html]))
       get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       assert_select '#console'
     end
 
     test 'does not render console if response format is not HTML' do
-      @app = Middleware.new(Application.new(response_content_type: Mime::JSON))
+      @app = Middleware.new(Application.new(response_content_type: Mime[:json]))
       get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       assert_select '#console', 0
@@ -85,7 +85,7 @@ module WebConsole
     end
 
     test "doesn't render console in non html response" do
-      @app = Middleware.new(Application.new(response_content_type: Mime::JSON))
+      @app = Middleware.new(Application.new(response_content_type: Mime[:json]))
       get '/', params: nil, headers: { 'web_console.binding' => binding }
 
       assert_select '#console', 0
@@ -172,7 +172,7 @@ module WebConsole
 
       def update_path_args(path)
         unless path[:headers]
-          path.merge!(headers: { 'HTTP_ACCEPT' => Mime::WEB_CONSOLE_V2 })
+          path.merge!(headers: { 'HTTP_ACCEPT' => Mime[:web_console_v2] })
         end
       end
 

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -43,7 +43,7 @@ module WebConsole
     end
 
     test '#acceptable? is truthy for current version' do
-      req = xhr('http://example.com', 'HTTP_ACCEPT' => "#{Mime::WEB_CONSOLE_V2}")
+      req = xhr('http://example.com', 'HTTP_ACCEPT' => "#{Mime[:web_console_v2]}")
 
       assert req.acceptable?
     end


### PR DESCRIPTION
We have deprecated the reference of custom Mime-Types through Mime
constants.

See rails/rails@efc6dd550ee49e7e443f9d72785caa0f240def53 and rails/rails#21869.

I have to backport this to the 2-0-stable branch and will release a new
2.x.x release once #164 is resolved.

Closes #167.