### PR TITLE
Fix method name typo

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -16,7 +16,7 @@ module WebConsole
 
     def call(env)
       request = create_regular_or_whiny_request(env)
-      return @app.call(env) unless request.from_whitelited_ip?
+      return @app.call(env) unless request.from_whitelisted_ip?
 
       if id = id_for_repl_session_update(request)
         return update_repl_session(id, request)

--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -12,7 +12,7 @@ module WebConsole
     #
     # For a request to hit Web Console features, it needs to come from a white
     # listed IP.
-    def from_whitelited_ip?
+    def from_whitelisted_ip?
       whitelisted_ips.include?(strict_remote_ip)
     end
 

--- a/lib/web_console/whiny_request.rb
+++ b/lib/web_console/whiny_request.rb
@@ -4,8 +4,8 @@ module WebConsole
   # If any calls to +from_whitelisted_ip?+ and +acceptable_content_type?+
   # return false, an info log message will be displayed in users' logs.
   class WhinyRequest < SimpleDelegator
-    def from_whitelited_ip?
-      whine_unless request.from_whitelited_ip? do
+    def from_whitelisted_ip?
+      whine_unless request.from_whitelisted_ip? do
         "Cannot render console from #{request.remote_ip}! " \
           "Allowed networks: #{request.whitelisted_ips}"
       end

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -6,40 +6,40 @@ module WebConsole
       Request.stubs(:whitelisted_ips).returns(IPAddr.new('127.0.0.1'))
     end
 
-    test '#from_whitelited_ip? is falsy for blacklisted IPs' do
+    test '#from_whitelisted_ip? is falsy for blacklisted IPs' do
       req = request('http://example.com', 'REMOTE_ADDR' => '0.0.0.0')
 
-      assert_not req.from_whitelited_ip?
+      assert_not req.from_whitelisted_ip?
     end
 
-    test '#from_whitelited_ip? is truthy for whitelisted IPs' do
+    test '#from_whitelisted_ip? is truthy for whitelisted IPs' do
       req = request('http://example.com', 'REMOTE_ADDR' => '127.0.0.1')
 
-      assert req.from_whitelited_ip?
+      assert req.from_whitelisted_ip?
     end
 
     test '#from_whitelisted_ip? is truthy for whitelisted IPs via whitelisted proxies' do
       req = request('http://example.com', 'REMOTE_ADDR' => '127.0.0.1', 'HTTP_X_FORWARDED_FOR' => '127.0.0.0')
 
-      assert req.from_whitelited_ip?
+      assert req.from_whitelisted_ip?
     end
 
     test '#from_whitelisted_ip? is falsy for blacklisted IPs via whitelisted proxies' do
       req = request('http://example.com', 'REMOTE_ADDR' => '127.0.0.1', 'HTTP_X_FORWARDED_FOR' => '0.0.0.0')
 
-      assert_not req.from_whitelited_ip?
+      assert_not req.from_whitelisted_ip?
     end
 
     test '#from_whitelisted_ip? is falsy for lying blacklisted IPs via whitelisted proxies' do
       req = request('http://example.com', 'REMOTE_ADDR' => '127.0.0.1', 'HTTP_X_FORWARDED_FOR' => '10.0.0.0, 127.0.0.0')
 
-      assert_not req.from_whitelited_ip?
+      assert_not req.from_whitelisted_ip?
     end
 
     test '#from_whitelisted_ip? is falsy for whitelisted IPs via blacklisted proxies' do
       req = request('http://example.com', 'REMOTE_ADDR' => '10.0.0.0', 'HTTP_X_FORWARDED_FOR' => '127.0.0.0')
 
-      assert_not req.from_whitelited_ip?
+      assert_not req.from_whitelisted_ip?
     end
 
     test '#acceptable? is truthy for current version' do

--- a/test/web_console/whiny_request_test.rb
+++ b/test/web_console/whiny_request_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 module WebConsole
   class WhinyRequestTest < ActiveSupport::TestCase
-    test '#from_whitelited_ip? logs out to stderr' do
+    test '#from_whitelisted_ip? logs out to stderr' do
       Request.stubs(:whitelisted_ips).returns(IPAddr.new('127.0.0.1'))
       assert_output_to_stderr do
         req = request('http://example.com', 'REMOTE_ADDR' => '0.0.0.0')
-        assert_not req.from_whitelited_ip?
+        assert_not req.from_whitelisted_ip?
       end
     end
 


### PR DESCRIPTION
I am not sure if this is a typo or it's written this way intentionally, but in case if it's a typo please merge.