### PR TITLE
Display a message with the IP web-console is seeing

### DIFF
--- a/lib/web_console/whiny_request.rb
+++ b/lib/web_console/whiny_request.rb
@@ -6,7 +6,7 @@ module WebConsole
   class WhinyRequest < SimpleDelegator
     def from_whitelisted_ip?
       whine_unless request.from_whitelisted_ip? do
-        "Cannot render console from #{request.remote_ip}! " \
+        "Cannot render console from #{request.strict_remote_ip}! " \
           "Allowed networks: #{request.whitelisted_ips}"
       end
     end


### PR DESCRIPTION
This is one part of the problem reported at #164. However, it doesn't fix the issue, though. :disappointed: It just gives the users better idea of what address web-console is actually seeing.

This is happening for developers running web-console in a virtual machine or a container with a Rails app behind an nginx or Apache proxy.

EDIT:

Actually @matthewd is correct (as always :blush:). The problem @brunze was getting was because in the docker setup, we are getting through two networks, so can't trust one and not the other, we have to trust both, to be sure that we can execute arbitrary code in there. Hopefully, with the proper display of the IP, folks will get hinted about this. I'll also try to document it for the next release.