### PR TITLE
use `#cause` instead of deprecated `#original_exception`

### DIFF
--- a/lib/web_console/extensions.rb
+++ b/lib/web_console/extensions.rb
@@ -14,7 +14,7 @@ ActionDispatch::DebugExceptions.class_eval do
       # exception following. The backtrace in the view is generated from
       # reaching out to original_exception in the view.
       if error.is_a?(ActionView::Template::Error)
-        env['web_console.exception'] = error.original_exception
+        env['web_console.exception'] = error.cause
       end
     end
   end


### PR DESCRIPTION
`#original_exception` was deprecated in https://github.com/rails/rails/commit/266455cf25aba942b8717ceb0269d66f719b5696