### PR TITLE
Don't load `ActionView::Base` on the application boot

### DIFF
--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -12,10 +12,11 @@ require 'web_console/middleware'
 require 'web_console/whitelist'
 require 'web_console/request'
 require 'web_console/response'
-require 'web_console/view'
 require 'web_console/whiny_request'
 
 module WebConsole
+  autoload :View, 'web_console/view'
+
   mattr_accessor :logger
   @@logger = ActiveSupport::Logger.new($stderr)
 


### PR DESCRIPTION
Fixes settings on the rails initializers.

Closes https://github.com/rails/rails/issues/22606