### PR TITLE
Log internal web-console errors

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -15,34 +15,41 @@ module WebConsole
     end
 
     def call(env)
-      request = create_regular_or_whiny_request(env)
-      return @app.call(env) unless request.from_whitelisted_ip?
+      app_exception = catch :app_exception do
+        request = create_regular_or_whiny_request(env)
+        return call_app(env) unless request.from_whitelisted_ip?
 
-      if id = id_for_repl_session_update(request)
-        return update_repl_session(id, request)
-      elsif id = id_for_repl_session_stack_frame_change(request)
-        return change_stack_trace(id, request)
+        if id = id_for_repl_session_update(request)
+          return update_repl_session(id, request)
+        elsif id = id_for_repl_session_stack_frame_change(request)
+          return change_stack_trace(id, request)
+        end
+
+        status, headers, body = call_app(env)
+
+        if exception = env['web_console.exception']
+          session = Session.from_exception(exception)
+        elsif binding = env['web_console.binding']
+          session = Session.from_binding(binding)
+        end
+
+        if session && acceptable_content_type?(headers)
+          response = Response.new(body, status, headers)
+          template = Template.new(env, session)
+
+          response.headers["X-Web-Console-Session-Id"] = session.id
+          response.headers["X-Web-Console-Mount-Point"] = mount_point
+          response.write(template.render('index'))
+          response.finish
+        else
+          [ status, headers, body ]
+        end
       end
-
-      status, headers, body = @app.call(env)
-
-      if exception = env['web_console.exception']
-        session = Session.from_exception(exception)
-      elsif binding = env['web_console.binding']
-        session = Session.from_binding(binding)
-      end
-
-      if session && acceptable_content_type?(headers)
-        response = Response.new(body, status, headers)
-        template = Template.new(env, session)
-
-        response.headers["X-Web-Console-Session-Id"] = session.id
-        response.headers["X-Web-Console-Mount-Point"] = mount_point
-        response.write(template.render('index'))
-        response.finish
-      else
-        [ status, headers, body ]
-      end
+    rescue => e
+      WebConsole.logger.error("\n#{e.class}: #{e}\n\tfrom #{e.backtrace.join("\n\tfrom ")}")
+      raise e
+    ensure
+      raise app_exception if Exception === app_exception
     end
 
     private
@@ -119,6 +126,12 @@ module WebConsole
         json_response(status: 406) do
           { output: I18n.t('errors.unacceptable_request') }
         end
+      end
+
+      def call_app(env)
+        @app.call(env)
+      rescue => e
+        throw :app_exception, e
       end
   end
 end

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -15,6 +15,10 @@ module WebConsole
       ActiveSupport.on_load(:action_controller) do
         ActionController::Base.send(:include, Helper)
       end
+
+      if logger = ::Rails.logger
+        WebConsole.logger = logger
+      end
     end
 
     initializer 'web_console.development_only' do

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -157,6 +157,12 @@ module WebConsole
       assert_equal(406, response.status)
     end
 
+    test 'reraises application errors' do
+      @app = proc { raise }
+
+      assert_raises(RuntimeError) { get '/' }
+    end
+
     private
 
       # Override the put and post testing helper of ActionDispatch to customize http headers

--- a/test/web_console/whiny_request_test.rb
+++ b/test/web_console/whiny_request_test.rb
@@ -4,18 +4,13 @@ module WebConsole
   class WhinyRequestTest < ActiveSupport::TestCase
     test '#from_whitelisted_ip? logs out to stderr' do
       Request.stubs(:whitelisted_ips).returns(IPAddr.new('127.0.0.1'))
-      assert_output_to_stderr do
-        req = request('http://example.com', 'REMOTE_ADDR' => '0.0.0.0')
-        assert_not req.from_whitelisted_ip?
-      end
+      WebConsole.logger.expects(:info)
+
+      req = request('http://example.com', 'REMOTE_ADDR' => '0.0.0.0')
+      assert_not req.from_whitelisted_ip?
     end
 
     private
-
-      def assert_output_to_stderr
-        output = capture(:stderr) { yield }
-        assert_not output.blank?
-      end
 
       def request(*args)
         request = Request.new(Rack::MockRequest.env_for(*args))


### PR DESCRIPTION
Currently, if an error is hit in web-console internals, the user sees
the `ActionPack::ShowExceptions` middleware page and nothing else.
Having a log of the error within the Rails application log can help the
developers send us bug reports or take an action in resolving it.

Thanks to Richard Schneeman for the push and implementation.
Closes #178.