### PR TITLE
Fix rails console invocation inside a Rails app

### DIFF
--- a/lib/web_console/extensions.rb
+++ b/lib/web_console/extensions.rb
@@ -1,4 +1,6 @@
 module Kernel
+  module_function
+
   # Instructs Web Console to render a console in the specified binding.
   #
   # If +bidning+ isn't explicitly given it will default to the binding of the


### PR DESCRIPTION
Railties can hook themselves into the `rails console` with:

```ruby
class Railtie < ::Rails::Railtie
  console do
    # Do something here.
  end
end
```

Now, since I introduced the `#console` method in `Kernel`, every object
responded to it, so this block was tried to be run on railties that
respond to it.

Marking the `#console` method _explicitly_ as `module_function`
solves this problem as it makes it `private` and the `#respond_to?`
calls during the railties initialization no longer lie.

Fixes #184.