### PR TITLE
Remove translation for error case

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -92,7 +92,7 @@ REPLConsole.prototype.commandHandle = function(line, callback) {
 
   function getErrorText(xhr) {
     if (!xhr.status) {
-      return "<%= t 'errors.connection_refused' %>";
+      return "Connection Refused";
     } else {
       return xhr.status + ' ' + xhr.statusText;
     }


### PR DESCRIPTION
When `ActionView::Base.raise_on_missing_translations = true` is set within the hosting rails application, the
web-console usage will fail unless one provides a translation for this error message.

IMO the error is understandable by itself and doesn't necessarily need a translation, so let's just ditch the `t` call.