### PR TITLE
Silence ActionView rendering information

### DIFF
--- a/lib/web_console/view.rb
+++ b/lib/web_console/view.rb
@@ -25,6 +25,14 @@ module WebConsole
       render(template: template, layout: 'layouts/inlined_string')
     end
 
+    # Custom ActionView::Base#render wrapper which silences all the log
+    # printings.
+    #
+    # Helps to keep the Rails logs clean during errors.
+    def render(*)
+      WebConsole.logger.silence { super }
+    end
+
     # Override method for ActionView::Helpers::TranslationHelper#t.
     #
     # This method escapes the original return value for JavaScript, since the


### PR DESCRIPTION
We use Action View a lot in web-console. It helps us build the UI we
inject on pages. However, using that much partials do make Action View
a tad too noisy.

We may have the argument that keeping this explicit is a good thing, and
we can see that web-console's rendering is actually slow.

However I would like to make the argument that web-console is an
internal thing as is and I'm doing this for the convenience of less
noise in the development logs.

### Before:

```
StandardError (StandardError):

app/controllers/exception_test_controller.rb:13:in `test_method'
app/controllers/exception_test_controller.rb:4:in `index'
  Rendering /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout
  Rendering /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
  Rendered /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb (2.8ms)
  Rendering /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
  Rendered /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.3ms)
  Rendering /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
  Rendered /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (7.9ms)
  Rendered /Users/genadi/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rails-6fb31638c8b6/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout (65.2ms)
  Rendering /Users/genadi/Development/web-console/lib/web_console/templates/index.html.erb
  Rendered /Users/genadi/Development/web-console/lib/web_console/templates/_markup.html.erb (0.3ms)
  Rendering /Users/genadi/Development/web-console/lib/web_console/templates/console.js.erb within layouts/javascript
  Rendering /Users/genadi/Development/web-console/lib/web_console/templates/_inner_console_markup.html.erb within layouts/inlined_string
  Rendered /Users/genadi/Development/web-console/lib/web_console/templates/_inner_console_markup.html.erb within layouts/inlined_string (0.3ms)
  Rendering /Users/genadi/Development/web-console/lib/web_console/templates/_prompt_box_markup.html.erb within layouts/inlined_string
  Rendered /Users/genadi/Development/web-console/lib/web_console/templates/_prompt_box_markup.html.erb within layouts/inlined_string (0.2ms)
  Rendering /Users/genadi/Development/web-console/lib/web_console/templates/style.css.erb within layouts/inlined_string
  Rendered /Users/genadi/Development/web-console/lib/web_console/templates/style.css.erb within layouts/inlined_string (0.4ms)
  Rendered /Users/genadi/Development/web-console/lib/web_console/templates/console.js.erb within layouts/javascript (29.2ms)
  Rendering /Users/genadi/Development/web-console/lib/web_console/templates/main.js.erb within layouts/javascript
  Rendered /Users/genadi/Development/web-console/lib/web_console/templates/main.js.erb within layouts/javascript (0.3ms)
  Rendered /Users/genadi/Development/web-console/lib/web_console/templates/index.html.erb (53.6ms)
```

### After:

```
StandardError (StandardError):

app/controllers/exception_test_controller.rb:13:in `test_method'
app/controllers/exception_test_controller.rb:4:in `index'
  Rendering /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout
  Rendering /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
  Rendered /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb (2.6ms)
  Rendering /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
  Rendered /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.3ms)
  Rendering /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
  Rendered /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (7.0ms)
  Rendered /Users/genadi/Development/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout (47.5ms)
```