### PR TITLE
Fix for View#only_on_error_page

### DIFF
--- a/lib/web_console/templates/layouts/javascript.erb
+++ b/lib/web_console/templates/layouts/javascript.erb
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" data-template="<%= @template %>">
 (function() {
   <%= yield %>
 }).call(this);

--- a/lib/web_console/view.rb
+++ b/lib/web_console/view.rb
@@ -5,7 +5,7 @@ module WebConsole
     # The error pages are special, because they are the only pages that
     # currently require multiple bindings. We get those from exceptions.
     def only_on_error_page(*args)
-      yield if @env['web_console.exception'].present?
+      yield if Thread.current[:__web_console_exception].present?
     end
 
     # Render JavaScript inside a script tag and a closure.

--- a/lib/web_console/view.rb
+++ b/lib/web_console/view.rb
@@ -14,6 +14,7 @@ module WebConsole
     # script tag and enclosed in a closure, so you don't have to worry for
     # leaking globals, unless you explicitly want to.
     def render_javascript(template)
+      assign(template: template)
       render(template: template, layout: 'layouts/javascript')
     end
 

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -58,6 +58,14 @@ module WebConsole
       assert_select 'body > #console'
     end
 
+    test 'render error_page.js from web_console.exception' do
+      Thread.current[:__web_console_exception] = raise_exception
+
+      get '/', params: nil
+
+      assert_select 'body > script[data-template=error_page]'
+    end
+
     test 'render console if response format is HTML' do
       Thread.current[:__web_console_binding] = binding
       @app = Middleware.new(Application.new(response_content_type: Mime[:html]))


### PR DESCRIPTION
This is a fix for `View#only_on_error_page`.

* Use `Thread.current[:__web_console_exception]` instead of `@env['web_console.exception']` on the View class
  - as the `only_on_error_page` method didn't work properly, and the `error_page.js.erb` wasn't rendered
* Render a script tag with its template name (for the below test)
* Add a test for rendering error_page.js.erb

Thank you.