### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,26 @@
 language: ruby
 
 rvm:
-  - 2.2.3
+  - 2.3.1
+  - 2.2.5
   - ruby-head
   - rbx-2
   - jruby
 
-gemfile:
-  - Gemfile
-
 env:
   global:
     - JRUBY_OPTS=--dev
-    - TEST_SUITE=test
-
-sudo: false
 
 script:
-  - bundle exec rake ${TEST_SUITE}
+  - bundle exec rake ${TEST_SUITE:-test}
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-2
     - rvm: jruby
-    - gemfile: Gemfile
+    - env: TEST_SUITE=test:templates
+  include:
+    - env: TEST_SUITE=test:templates
+      rvm: 2.2


### PR DESCRIPTION
This pull request is to update .travis.yml:

* Remove "Gemfile" from allow_failures because all build jobs were allowed to fail
* Update ruby from "2.2.3" to "2.2.5" and use "2.3.1".
* No wait for jobs which are allowed to fail by "fast_finish"
* Enable to run tests for templates

Thanks.