### PR TITLE
Let FakeMiddleware to require "lib/web_console.rb"

### DIFF
--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -1,11 +1,7 @@
 require 'action_view'
-require 'action_dispatch'
-require 'active_support/core_ext/string/access'
-require 'json'
-require 'web_console/whitelist'
-require 'web_console/request'
-require 'web_console/view'
+require 'web_console'
 require 'web_console/testing/helper'
+Mime = { web_console_v2: 'fake' }
 
 module WebConsole
   module Testing


### PR DESCRIPTION
On testing templates, the `FakeMiddleware` caused an error when the `WebConsole.logger` method is missing, so we cannot run test suites for templates.

Previously, the "lib/web_console.rb" required all modules, and it might cause some troubles on the fake middleware (but I don't remember the details), but now it is using ActiveSupport::Autoload, so we don't worry about the troubles and the middleware can require it.

And the method missing error is also fixed by it. Thank you.