### PR TITLE
Enhancement for session binding

### DIFF
--- a/lib/web_console/session.rb
+++ b/lib/web_console/session.rb
@@ -43,7 +43,7 @@ module WebConsole
     def initialize(bindings)
       @id = SecureRandom.hex(16)
       @bindings = Array(bindings)
-      @evaluator = Evaluator.new(@bindings[0])
+      @evaluator = Evaluator.new(initial_binding)
 
       store_into_memory
     end
@@ -63,6 +63,10 @@ module WebConsole
     end
 
     private
+
+      def initial_binding
+        @bindings.find { |b| b.eval('__FILE__').to_s.start_with?(Rails.root.to_s) }
+      end
 
       def store_into_memory
         inmemory_storage[id] = self

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,3 +76,11 @@ if ActiveSupport::TestCase.method_defined?(:fixture_path=)
 end
 
 require 'mocha/mini_test'
+
+module External
+  def self.exception
+    raise
+  rescue => exc
+    exc
+  end
+end

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -133,7 +133,7 @@ module WebConsole
     end
 
     test 'can switch bindings on error pages' do
-      session = Session.new(exception = raise_exception)
+      session = Session.new(raise_exception.bindings)
 
       Session.stubs(:from).returns(session)
 

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -36,6 +36,7 @@ module WebConsole
     end
 
     setup do
+      Rails.stubs(:root).returns Pathname(__FILE__).parent
       Request.stubs(:whitelisted_ips).returns(IPAddr.new('0.0.0.0/0'))
 
       Middleware.mount_point = ''

--- a/test/web_console/session_test.rb
+++ b/test/web_console/session_test.rb
@@ -17,8 +17,9 @@ module WebConsole
     end
 
     setup do
+      Rails.stubs(:root).returns Pathname(__FILE__).parent
       Session.inmemory_storage.clear
-      @session = Session.new TOPLEVEL_BINDING
+      @session = Session.new(binding)
     end
 
     test 'returns nil when a session is not found' do

--- a/test/web_console/session_test.rb
+++ b/test/web_console/session_test.rb
@@ -34,6 +34,11 @@ module WebConsole
       assert_equal "=> 42\n", @session.eval('40 + 2')
     end
 
+    test 'find first binding of the rails app' do
+      session = Session.new(External.exception.bindings)
+      assert_equal session.eval('__FILE__'), "=> \"#{__FILE__}\"\n"
+    end
+
     test '#from can create session from a single binding' do
       saved_line, saved_binding = __LINE__, binding
       Thread.current[:__web_console_binding] = saved_binding


### PR DESCRIPTION
This pull request is to find a initial binding for each session. We use the first binding that is in `Rails.root` as the initial binding.

##### Issue

From #194:

> This often put is in a situation where an error is raised inside of framework code that is invoked from an application code. The error the user sees looks like it's raised from the application code (as this is the piece of code the error page shows), while the binding we have for the console is deep inside the framework code and it looks like Web Console "doesn't work".


##### Details

* Find the first binding that is in `Rails.root`
* Set stub for `Rails.root` to return suitable path on testing

Thank you.