### PR TITLE
Reset "Thread.current" for each test on middleware's tests

### DIFF
--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -36,6 +36,8 @@ module WebConsole
     end
 
     setup do
+      Thread.current[:__web_console_exception] = nil
+      Thread.current[:__web_console_binding] = nil
       Rails.stubs(:root).returns Pathname(__FILE__).parent
       Request.stubs(:whitelisted_ips).returns(IPAddr.new('0.0.0.0/0'))
 


### PR DESCRIPTION
This pull request is to reset `Thread.current` for each test on the `middleware_test.rb`.

The object is reused for each test, and the last value of the object is kept until it is updated. Sometimes, it makes a test case failed (e.g., https://travis-ci.org/sh19910711/web-console/jobs/135552822#L328).