### PR TITLE
Simplify the logic of the "Middleware#call" method

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -26,18 +26,17 @@ module WebConsole
         end
 
         status, headers, body = call_app(env)
+        response = Response.new(body, status, headers)
 
         if session = Session.from(Thread.current) and acceptable_content_type?(headers)
-          response = Response.new(body, status, headers)
           template = Template.new(env, session)
-
           response.headers["X-Web-Console-Session-Id"] = session.id
           response.headers["X-Web-Console-Mount-Point"] = mount_point
-          response.write(template.render('index'))
-          response.finish
-        else
-          [ status, headers, body ]
+          response.insert_head(template.render('head'))
+          response.insert_body(template.render('index'))
         end
+
+        response.finish
       end
     rescue => e
       WebConsole.logger.error("\n#{e.class}: #{e}\n\tfrom #{e.backtrace.join("\n\tfrom ")}")

--- a/lib/web_console/templates/error_page.js.erb
+++ b/lib/web_console/templates/error_page.js.erb
@@ -1,28 +1,30 @@
 // Try intercept traces links in Rails 4.2.
-var traceFrames = document.getElementsByClassName('trace-frames');
-var selectedFrame, currentSource = document.getElementById('frame-source-0');
+document.addEventListener('DOMContentLoaded', function() {
+  var traceFrames = document.getElementsByClassName('trace-frames');
+  var selectedFrame, currentSource = document.getElementById('frame-source-0');
 
-// Add click listeners for all stack frames
-for (var i = 0; i < traceFrames.length; i++) {
-  traceFrames[i].addEventListener('click', function(e) {
-    e.preventDefault();
-    var target = e.target;
-    var frameId = target.dataset.frameId;
+  // Add click listeners for all stack frames
+  for (var i = 0; i < traceFrames.length; i++) {
+    traceFrames[i].addEventListener('click', function(e) {
+      e.preventDefault();
+      var target = e.target;
+      var frameId = target.dataset.frameId;
 
-    // Change the binding of the console.
-    changeBinding(frameId, function() {
-      if (selectedFrame) {
-        selectedFrame.className = selectedFrame.className.replace("selected", "");
-      }
+      // Change the binding of the console.
+      changeBinding(frameId, function() {
+        if (selectedFrame) {
+          selectedFrame.className = selectedFrame.className.replace("selected", "");
+        }
 
-      target.className += " selected";
-      selectedFrame = target;
+        target.className += " selected";
+        selectedFrame = target;
+      });
+
+      // Change the extracted source code
+      changeSourceExtract(frameId);
     });
-
-    // Change the extracted source code
-    changeSourceExtract(frameId);
-  });
-}
+  }
+});
 
 function changeBinding(frameId, callback) {
   REPLConsole.currentSession.switchBindingTo(frameId, callback);

--- a/lib/web_console/templates/head.html.erb
+++ b/lib/web_console/templates/head.html.erb
@@ -1,0 +1,4 @@
+<%= render_javascript 'console' %>
+<% only_on_error_page do %>
+  <%= render_javascript 'error_page' %>
+<% end %>

--- a/lib/web_console/templates/index.html.erb
+++ b/lib/web_console/templates/index.html.erb
@@ -1,8 +1,2 @@
 <%= render 'markup' %>
-
-<%= render_javascript 'console' %>
 <%= render_javascript 'main' %>
-
-<% only_on_error_page do %>
-  <%= render_javascript 'error_page' %>
-<% end %>

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -66,7 +66,7 @@ module WebConsole
 
       get '/', params: nil
 
-      assert_select 'body > script[data-template=error_page]'
+      assert_select 'head > script[data-template=error_page]'
     end
 
     test 'render console if response format is HTML' do


### PR DESCRIPTION
This pull request is to simplify the logic of the `Middleware#call` method. The followings are the changes:

* Use `Rack::Response` instead of struct object in `response.rb`
* Move template scripts into the head of HTML document

In the near future, I will add an experimental feature to fire Web Console from anywhere (something like Web API). In order to hijack XHR or something else, we need to insert scripts into the head of HTML document.

Thank you.