### PR TITLE
Use first binding when there is no application binding

### DIFF
--- a/lib/web_console/session.rb
+++ b/lib/web_console/session.rb
@@ -43,7 +43,7 @@ module WebConsole
     def initialize(bindings)
       @id = SecureRandom.hex(16)
       @bindings = Array(bindings)
-      @evaluator = Evaluator.new(initial_binding)
+      @evaluator = Evaluator.new(application_binding || @bindings.first)
 
       store_into_memory
     end
@@ -64,7 +64,7 @@ module WebConsole
 
     private
 
-      def initial_binding
+      def application_binding
         @bindings.find { |b| b.eval('__FILE__').to_s.start_with?(Rails.root.to_s) }
       end
 

--- a/test/web_console/session_test.rb
+++ b/test/web_console/session_test.rb
@@ -39,6 +39,15 @@ module WebConsole
       assert_equal session.eval('__FILE__'), "=> \"#{__FILE__}\"\n"
     end
 
+    test 'use first binding if no application bindings' do
+      binding = Object.new
+      binding.expects(:eval).with('__FILE__').returns 'framework'
+      binding.expects(:eval).with('called?').returns 'yes'
+
+      session = Session.new(binding)
+      assert_equal session.eval('called?'), "=> \"yes\"\n"
+    end
+
     test '#from can create session from a single binding' do
       saved_line, saved_binding = __LINE__, binding
       Thread.current[:__web_console_binding] = saved_binding


### PR DESCRIPTION
If an error happens inside the framework before loading our application, the `ActionDispatch` shows traces for the framework. It could be outside of `Rails.root`, so we have to fallback to the first one. This pull request changes to use the first binding when there is no application binding.

Thank you.