### PR TITLE
Map bindings to traces based on the trace __FILE__ and __LINE__

### DIFF
--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -7,6 +7,7 @@ module WebConsole
 
   autoload :View
   autoload :Evaluator
+  autoload :ExceptionMapper
   autoload :Session
   autoload :Response
   autoload :Request

--- a/lib/web_console/exception_mapper.rb
+++ b/lib/web_console/exception_mapper.rb
@@ -1,0 +1,33 @@
+module WebConsole
+  class ExceptionMapper
+    def initialize(exception)
+      @backtrace = exception.backtrace
+      @bindings = exception.bindings
+    end
+
+    def first
+      guess_the_first_application_binding || @bindings.first
+    end
+
+    def [](index)
+      guess_binding_for_index(index) || @bindings[index]
+    end
+
+    private
+
+    def guess_binding_for_index(index)
+      file, line = @backtrace[index].to_s.split(':')
+      line = line.to_i
+
+      @bindings.find do |binding|
+        binding.eval('__FILE__') == file && binding.eval('__LINE__') == line
+      end
+    end
+
+    def guess_the_first_application_binding
+      @bindings.find do |binding|
+        binding.eval('__FILE__').to_s.start_with?(Rails.root.to_s)
+      end
+    end
+  end
+end

--- a/lib/web_console/session.rb
+++ b/lib/web_console/session.rb
@@ -30,9 +30,9 @@ module WebConsole
       # storage.
       def from(storage)
         if exc = storage[:__web_console_exception]
-          new(exc.bindings)
+          new(ExceptionMapper.new(exc))
         elsif binding = storage[:__web_console_binding]
-          new(binding)
+          new([binding])
         end
       end
     end
@@ -42,8 +42,8 @@ module WebConsole
 
     def initialize(bindings)
       @id = SecureRandom.hex(16)
-      @bindings = Array(bindings)
-      @evaluator = Evaluator.new(application_binding || @bindings.first)
+      @bindings = bindings
+      @evaluator = Evaluator.new(bindings.first)
 
       store_into_memory
     end
@@ -63,10 +63,6 @@ module WebConsole
     end
 
     private
-
-      def application_binding
-        @bindings.find { |b| b.eval('__FILE__').to_s.start_with?(Rails.root.to_s) }
-      end
 
       def store_into_memory
         inmemory_storage[id] = self

--- a/test/dummy/app/views/helper_error/index.html.erb
+++ b/test/dummy/app/views/helper_error/index.html.erb
@@ -1,2 +1,2 @@
 <% @ok = 42 %>
-<% raise %>
+<% params.fetch(:bad_key) %>

--- a/test/web_console/exception_mapper_test.rb
+++ b/test/web_console/exception_mapper_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+module WebConsole
+  class ExcetionMapperTest < ActiveSupport::TestCase
+    test '#first tries to find the first application binding' do
+      Rails.stubs(:root).returns Pathname(__FILE__).parent
+
+      mapper = ExceptionMapper.new(External.exception)
+
+      assert_equal __FILE__, mapper.first.eval('__FILE__')
+    end
+
+    test '.[] tries match the binding for trace index' do
+      exception = External.exception
+      mapper = ExceptionMapper.new(exception)
+
+      last_index = exception.backtrace.count - 1
+      file, line = exception.backtrace.last.split(':')
+
+      assert_equal file, mapper[last_index].eval('__FILE__')
+      assert_equal line.to_i, mapper[last_index].eval('__LINE__')
+    end
+
+    test '.[] fall backs to index if no trace can be found' do
+      exception = External.exception
+      mapper = ExceptionMapper.new(exception)
+
+      unbound_index = exception.backtrace.count
+
+      assert_nil mapper[unbound_index]
+    end
+  end
+end

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -124,7 +124,7 @@ module WebConsole
     end
 
     test 'can evaluate code and return it as a JSON' do
-      session, line = Session.new(binding), __LINE__
+      session, line = Session.new([binding]), __LINE__
 
       Session.stubs(:from).returns(session)
 
@@ -148,7 +148,7 @@ module WebConsole
     test 'can be changed mount point' do
       Middleware.mount_point = '/customized/path'
 
-      session, line = Session.new(binding), __LINE__
+      session, line = Session.new([binding]), __LINE__
       put "/customized/path/repl_sessions/#{session.id}", params: { input: '__LINE__' }, xhr: true
 
       assert_equal({ output: "=> #{line}\n" }.to_json, response.body)


### PR DESCRIPTION
Currently, we naively map exception bindings by the exception
backtrace's indexes. This doesn't work as the backtraces and the
bindings doesn't map one to one and we're most likely to be out of sync
in a couple of trace indexes.

With this change, I try to be smarter about the binding that corresponds
to an exception backtrace index. The `ExceptionMapper` objects tries to
map to a binding based on the __FILE__ and __LINE__ of the trace behind
that index. It also hides this transformation in an interface similar to
an `Array`, so we didn't needed to change much backend code and any
frontend code.

Right now, if you go and click through all the traces, you get the
binding right in most of the times. I can imagine we can still be off in
exceptions with custom backtraces, but we'll be off only for a couple of
bindings and not everything after those special traces.

In any case, I think this can fix a lot of the `web-console doesn't
work` cases for Rails 5.