### PR TITLE
Deny to render web console for XHR

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -27,7 +27,7 @@ module WebConsole
 
         status, headers, body = call_app(env)
 
-        if session = Session.from(Thread.current) and acceptable_content_type?(headers)
+        if session = Session.from(Thread.current) and acceptable_content_type?(headers) and not request.xhr?
           response = Response.new(body, status, headers)
           template = Template.new(env, session)
 


### PR DESCRIPTION
For a security reason, this patch changes the middleware to deny to render console if the request is XHR.

The middleware of Web Console allowed to render console into view even if the request via XHR. Due to that, it also allowed scripts outside of application to get a session ID of Web Console, and it opened doors for DNS rebinding attacks.

Ref: https://benmmurphy.github.io/blog/2016/07/11/rails-webconsole-dns-rebinding/