### PR TITLE
Add support for RAILS_RELATIVE_ROOT

### DIFF
--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -40,6 +40,9 @@ module WebConsole
       if mount_point = config.web_console.mount_point
         Middleware.mount_point = mount_point.chomp('/')
       end
+      if root = Rails.application.config.relative_url_root
+        Middleware.mount_point = File.join(root, Middleware.mount_point)
+      end
     end
 
     initializer 'web_console.template_paths' do


### PR DESCRIPTION
#### Issue

If the `RAILS_RELATIVE_ROOT` is set, Web Console could be missing its end-point, and it could return "404 Not Found" (this issue was reported in [this article](http://qiita.com/yakumo/items/3a5b8a54a55ea2a90f7e) by @yakumo-saki :bow: ).

In this pull request, in order to fix it, the initializer of the Middleware.mount_point inserts
the relative root before the mount point if the configuration is set.

#### An example of situations

```ruby
map '/relative/root' do
  run MyApp
end
```

```shell
$ RAILS_RELATIVE_URL_ROOT=/relative/root bundle exec rails s
```

```text
>> hello
404 Not Found
```