### PR TITLE
Remove duplicated words in auto completing

### DIFF
--- a/lib/web_console/context.rb
+++ b/lib/web_console/context.rb
@@ -29,11 +29,11 @@ module WebConsole
       ]
 
       def global
-        GLOBAL_OBJECTS.map { |cmd| eval(cmd) }.flatten
+        SortedSet.new GLOBAL_OBJECTS.map { |cmd| eval(cmd) }.flatten
       end
 
       def local(objpath)
-        [
+        SortedSet.new [
           eval("#{objpath}.methods").map { |m| "#{objpath}.#{m}" },
           eval("#{objpath}.constants").map { |c| "#{objpath}::#{c}" },
         ].flatten

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -77,6 +77,7 @@ Autocomplete.prototype.onKeyDown = function(ev) {
   var self = this;
 
   function move(nextCurrent) {
+    if (! self.words.length) return;
     if (0 <= self.current && self.current < self.words.length) removeClass(self.view.children[self.current], 'selected');
     addClass(self.view.children[nextCurrent], 'selected');
     self.current = nextCurrent;

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -45,8 +45,7 @@ function CommandStorage() {
 }
 
 function Autocomplete(words, prefix) {
-  this.words = words.concat(); // to clone object
-  this.words.sort(); // by alphabetically order
+  this.words = words;
   this.current = -1;
   this.left = 0; // [left, right)
   this.right = words.length;

--- a/test/templates/test/auto_complete_test.js
+++ b/test/templates/test/auto_complete_test.js
@@ -4,6 +4,14 @@ suite('Autocomplete', function() {
     this.refine = function(prefix) { this.ac.refine(prefix); };
   });
 
+  test('does nothing if the word list is empty', function() {
+    var ac = new Autocomplete([]);
+    assert.doesNotThrow(function() {
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_ENTER));
+    });
+  });
+
   test('empty string', function() {
     this.refine('');
 

--- a/test/templates/test/repl_console_test.js
+++ b/test/templates/test/repl_console_test.js
@@ -148,8 +148,8 @@ suite('REPLCosnole', function() {
           assert.equal('something', word);
           done();
         });
-        self.console.onKeyDown(TestHelper.keyDown(9)); // tab
-        self.console.onKeyDown(TestHelper.keyDown(13)); // enter
+        self.console.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+        self.console.onKeyDown(TestHelper.keyDown(TestHelper.KEY_ENTER));
       }, 100);
     });
   });

--- a/test/templates/test/test_helper.js
+++ b/test/templates/test/test_helper.js
@@ -15,19 +15,6 @@
     },
     keyDown: function(keyCode) {
       return new FakeKeyEvent(keyCode);
-    },
-    randomString: function() {
-      Math.random().toString(36).substring(2);
-    },
-    prepareStageElement: function() {
-      before(function() {
-        this.stageElement = document.createElement("div");
-        this.stageElement.style.display = "none";
-        document.body.appendChild(this.stageElement);
-      });
-      afterEach(function() {
-        this.stageElement.innerHTML = "";
-      });
     }
   };
 

--- a/test/templates/test/test_helper.js
+++ b/test/templates/test/test_helper.js
@@ -1,20 +1,20 @@
 (function() {
   'use strict';
 
-  function FakeKeyEvent(key) {
-    this.keyCode = key;
-    this.preventDefault = function() {};
-    this.stopPropagation = function() {};
-  }
-
   var TestHelper = {
+    KEY_TAB: 9,
+    KEY_ENTER: 13,
     triggerEvent: function(el, eventName) {
       var event = document.createEvent("MouseEvents");
       event.initEvent(eventName, true, true); // type, bubbles, cancelable
       el.dispatchEvent(event);
     },
     keyDown: function(keyCode) {
-      return new FakeKeyEvent(keyCode);
+      return {
+        keyCode: keyCode,
+        preventDefault: function() {},
+        stopPropagation: function() {}
+      };
     }
   };
 


### PR DESCRIPTION
This pull request has the changes for the auto completion.

* Remove duplicated words in auto completing
  - Some methods (like `public_method`) could appear in the list for the auto completion twice
* Remove unused test helpers for template testing
* Do nothing if no words is passsed to the auto completion
  - It caused some exceptions to handle view of the auto completion

Thank you.