### PR TITLE
Stop using Rails.logger.silence as it has been removed in version 5.0

### DIFF
--- a/lib/web_console/view.rb
+++ b/lib/web_console/view.rb
@@ -31,7 +31,7 @@ module WebConsole
     #
     # Helps to keep the Rails logs clean during errors.
     def render(*)
-      WebConsole.logger.silence { super }
+      super
     end
 
     # Override method for ActionView::Helpers::TranslationHelper#t.


### PR DESCRIPTION
Signed-off-by: Maher Saif <clever.netman@gmail.com>