### PR TITLE
Trim suggested keywords in auto-completion

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -50,23 +50,31 @@ function Autocomplete(words, prefix) {
   this.left = 0; // [left, right)
   this.right = words.length;
   this.confirmed = false;
+  this.prefix = createSpan('...');
+  this.suffix = createSpan('...');
 
-  function createKeyword(label) {
+  function createSpan(label) {
     var el = document.createElement('span');
     el.innerText = label;
-    addClass(el, 'keyword');
     return el;
   }
 
   this.view = document.createElement('pre');
-  addClass(this.view, 'console-message');
-  addClass(this.view, 'auto-complete');
+  addClass(this.view, 'auto-complete console-message');
+
+  this.view.appendChild(this.prefix);
   for (var key in this.words) {
-    this.view.appendChild(createKeyword(this.words[key]));
+    this.view.appendChild(createSpan(this.words[key]));
   }
+  this.view.appendChild(this.suffix);
+  addClass(this.view.children, 'trimmed keyword');
 
   this.refine(prefix || '');
 }
+
+Autocomplete.prototype.item = function(x) {
+  return this.view.children[x+1];
+};
 
 Autocomplete.prototype.onFinished = function(callback) {
   this.onFinishedCallback = callback;
@@ -78,8 +86,10 @@ Autocomplete.prototype.onKeyDown = function(ev) {
 
   function move(nextCurrent) {
     if (! self.words.length) return;
-    if (0 <= self.current && self.current < self.words.length) removeClass(self.view.children[self.current], 'selected');
-    addClass(self.view.children[nextCurrent], 'selected');
+    if (0 <= self.current && self.current < self.words.length) removeClass(self.item(self.current), 'selected');
+    addClass(self.item(nextCurrent), 'selected');
+    self.trim(self.current, true);
+    self.trim(nextCurrent, false);
     self.current = nextCurrent;
   }
 
@@ -146,7 +156,7 @@ Autocomplete.prototype.refine = function(prefix) {
 
   function moveRight(l, r) {
     while (l < r && inc !== startsWith(self.words[l], prefix)) {
-      toggle(self.view.children[l]);
+      toggle(self.item(l));
       ++ l;
     }
     return l;
@@ -154,12 +164,13 @@ Autocomplete.prototype.refine = function(prefix) {
 
   function moveLeft(l, r) {
     while (l < r - 1 && inc !== startsWith(self.words[r - 1], prefix)) {
-      toggle(self.view.children[r - 1]);
+      toggle(self.item(r - 1));
       -- r;
     }
     return r;
   }
 
+  self.trim(self.current, true);
   if (inc) {
     self.left = moveRight(self.left, self.right);
     self.right = moveLeft(self.left, self.right);
@@ -167,12 +178,10 @@ Autocomplete.prototype.refine = function(prefix) {
     self.left = moveLeft(-1, self.left);
     self.right = moveRight(self.right, self.words.length);
   }
-
-  if (self.current < self.left) {
-    self.current = self.left - 1;
-  } else if (self.current > self.right) {
-    self.current = self.right;
+  if (this.current < this.left || this.current >= this.right) {
+    this.current = this.left - 1;
   }
+  self.trim(this.current, false);
 
   if (self.left + 1 >= self.right) {
     self.current = self.left;
@@ -743,7 +752,7 @@ function addClass(el, className) {
     for (var i = 0; i < el.length; ++ i) {
       addClass(el[i], className);
     }
-  } else {
+  } else if (!hasClass(el, className)) {
     el.className += " " + className;
   }
 }

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -102,6 +102,34 @@ Autocomplete.prototype.onKeyDown = function(ev) {
   return false;
 };
 
+Autocomplete.prototype.trim = function(from, needToTrim) {
+  var self = this;
+  var num = 5;
+
+  if (this.right - this.left > num) {
+    (this.left < from ? removeClass : addClass)(this.prefix, 'trimmed');
+    (from + num < this.right? removeClass : addClass)(this.suffix, 'trimmed');
+  } else {
+    addClass(this.prefix, 'trimmed');
+    addClass(this.suffix, 'trimmed');
+  }
+
+  function iterate(x) {
+    for (var i = 0; i < num; ++i, ++x) if (self.left <= x && x < self.right) {
+      toggleClass(self.item(x), 'trimmed');
+    }
+  }
+
+  var toggleClass = needToTrim ? addClass : removeClass;
+  if (from < this.left) {
+    iterate(this.left);
+  } else if (from + num - 1 >= this.right) {
+    iterate(this.right - num);
+  } else {
+    iterate(from);
+  }
+};
+
 Autocomplete.prototype.refine = function(prefix) {
   var inc = !this.prev || (prefix.length >= this.prev.length);
   this.prev = prefix;

--- a/lib/web_console/templates/style.css.erb
+++ b/lib/web_console/templates/style.css.erb
@@ -15,6 +15,7 @@
 .console .console-message.auto-complete .keyword { margin-right: 11px; }
 .console .console-message.auto-complete .keyword.selected { background: #FFF; color: #000; }
 .console .console-message.auto-complete .hidden { display: none; }
+.console .console-message.auto-complete .trimmed { display: none; }
 .console .console-focus .console-cursor { background: #FEFEFE; color: #333; font-weight: bold; }
 .console .resizer { background: #333; width: 100%; height: 4px; cursor: ns-resize; }
 .console .console-actions { padding-right: 3px; }

--- a/test/templates/test/auto_complete_test.js
+++ b/test/templates/test/auto_complete_test.js
@@ -1,16 +1,128 @@
 suite('Autocomplete', function() {
+  suite('Trimming', function() {
+    test('prefix and suffix stands for that the list includes trimmed elements', function() {
+      var ac = new Autocomplete(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+      assert.equal(ac.prefix, ac.view.children[0]);
+      assert.equal(ac.prefix.innerText, ac.view.children[0].innerText);
+      assert.equal(ac.suffix, ac.view.children[ac.words.length + 1]);
+      assert.equal(ac.suffix.innerText, ac.view.children[ac.words.length + 1].innerText);
+      assertTrimmed(ac.prefix);
+      assertNotTrimmed(ac.suffix);
+
+      // A B C D E ...
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertTrimmed(ac.prefix);
+      assertNotTrimmed(ac.suffix);
+
+      // ... B C D E F ...
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertNotTrimmed(ac.prefix);
+      assertNotTrimmed(ac.suffix);
+
+      // A: A B C D E ... (shift)
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB, { shiftKey: true }));
+      assertTrimmed(ac.prefix);
+      assertNotTrimmed(ac.suffix);
+
+      // ... D E F G H
+      for (var i = 0; i <= ac.words.indexOf('D'); ++i) ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertNotTrimmed(ac.prefix);
+      assertTrimmed(ac.suffix);
+    });
+
+    test('prefix and suffix are always trimmed if the list has few items', function() {
+      var ac = new Autocomplete(['A', 'B', 'C']);
+      assertTrimmed(ac.prefix);
+      assertTrimmed(ac.suffix);
+
+      // A
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertTrimmed(ac.prefix);
+      assertTrimmed(ac.suffix);
+
+      // B
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertTrimmed(ac.prefix);
+      assertTrimmed(ac.suffix);
+
+      // C
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertTrimmed(ac.prefix);
+      assertTrimmed(ac.suffix);
+    });
+
+    test('shows only five elements after the current element', function() {
+      var ac = new Autocomplete(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+
+      // A B C D E ...
+      assert.equal(-1, ac.current);
+      assertNotClass(ac, 0, 5, 'trimmed');
+      assertClass(ac, 5, ac.words.length, 'trimmed');
+
+      // A: A B C D E ...
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertNotClass(ac, 0, 5, 'trimmed');
+      assertClass(ac, 5, ac.words.length, 'trimmed');
+
+      // B: B C D E F ...
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertClass(ac, 0, 1, 'trimmed');
+      assertNotClass(ac, 1, 6, 'trimmed');
+      assertClass(ac, 6, ac.words.length, 'trimmed');
+
+      // A: A B C D E ... (shift)
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB, { shiftKey: true }));
+      assert.equal(0, ac.current);
+      assertNotClass(ac, 0, 5, 'trimmed');
+      assertClass(ac, 5, ac.words.length, 'trimmed');
+    });
+
+    test('keeps to show the last five elements', function() {
+      var ac = new Autocomplete(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+
+      // G: D E F G H
+      for (var i = 0; i <= ac.words.indexOf('G'); ++i) ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assert.equal(6, ac.current);
+      assertClass(ac, 0, 3, 'trimmed');
+      assertNotClass(ac, 3, ac.words.length, 'trimmed');
+
+      // H: D E F G H (keep last five elements)
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assert.equal(7, ac.current);
+      assertClass(ac, 0, 3, 'trimmed');
+      assertNotClass(ac, 3, ac.words.length, 'trimmed');
+
+      // A: A B C D E ...
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assertNotClass(ac, 0, 5, 'trimmed');
+      assertClass(ac, 5, ac.words.length, 'trimmed');
+
+      // H: D E F G H (shift)
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB, { shiftKey: true }));
+      assert.equal(7, ac.current);
+      assertClass(ac, 0, 3, 'trimmed');
+      assertNotClass(ac, 3, ac.words.length, 'trimmed');
+    });
+
+    test('shows five elements if prefix is passed', function() {
+      var ac = new Autocomplete(['A', 'B1', 'B2', 'B3', 'C'], 'B');
+      assert.equal(0, ac.current);
+      assertClass(ac, 0, 1, 'trimmed');
+      assertNotClass(ac, 1, 4, 'trimmed');
+      assertClass(ac, 4, ac.words.length, 'trimmed');
+
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      assert.equal(1, ac.current);
+      assertClass(ac, 0, 1, 'trimmed');
+      assertNotClass(ac, 1, 4, 'trimmed');
+      assertClass(ac, 4, ac.words.length, 'trimmed');
+    });
+  });
+
   suite('Refinements', function() {
     setup(function() {
       this.ac = new Autocomplete(['other', 'other2', 'something', 'somewhat', 'somewhere', 'test']);
       this.refine = function(prefix) { this.ac.refine(prefix); };
-    });
-
-    test('does nothing if the word list is empty', function() {
-      var ac = new Autocomplete([]);
-      assert.doesNotThrow(function() {
-        ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
-        ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_ENTER));
-      });
     });
 
     test('empty string', function() {
@@ -57,9 +169,39 @@ suite('Autocomplete', function() {
     });
   });
 
+  suite('Edge Cases', function() {
+    test('does nothing if the word list is empty', function() {
+      var ac = new Autocomplete([]);
+      assert.doesNotThrow(function() {
+        ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+        ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_ENTER));
+      });
+    });
+  });
+
+  function assertClass(ac, left, right, className) {
+    for (var i = left; i < right; ++i) {
+      assert.ok(hasClass(ac.item(i), className), i + '-th element shuold have ' + className);
+    }
+  }
+
+  function assertNotClass(ac, left, right, className) {
+    for (var i = left; i < right; ++i) {
+      assert.notOk(hasClass(ac.item(i), className), i + '-th element should not have ' + className);
+    }
+  }
+
   function assertRange(self, left, right, hiddenCnt) {
     assert.equal(left, self.ac.left, 'left');
     assert.equal(right, self.ac.right, 'right');
     if (hiddenCnt) assert.equal(hiddenCnt, self.ac.view.getElementsByClassName('hidden').length, 'hiddenCnt');
+  }
+
+  function assertTrimmed(el) {
+    assert.ok(hasClass(el, 'trimmed'));
+  }
+
+  function assertNotTrimmed(el) {
+    assert.notOk(hasClass(el, 'trimmed'));
   }
 });

--- a/test/templates/test/auto_complete_test.js
+++ b/test/templates/test/auto_complete_test.js
@@ -1,58 +1,60 @@
 suite('Autocomplete', function() {
-  setup(function() {
-    this.ac = new Autocomplete(['other', 'other2', 'something', 'somewhat', 'somewhere', 'test']);
-    this.refine = function(prefix) { this.ac.refine(prefix); };
-  });
-
-  test('does nothing if the word list is empty', function() {
-    var ac = new Autocomplete([]);
-    assert.doesNotThrow(function() {
-      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
-      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_ENTER));
+  suite('Refinements', function() {
+    setup(function() {
+      this.ac = new Autocomplete(['other', 'other2', 'something', 'somewhat', 'somewhere', 'test']);
+      this.refine = function(prefix) { this.ac.refine(prefix); };
     });
-  });
 
-  test('empty string', function() {
-    this.refine('');
+    test('does nothing if the word list is empty', function() {
+      var ac = new Autocomplete([]);
+      assert.doesNotThrow(function() {
+        ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+        ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_ENTER));
+      });
+    });
 
-    assert(!this.ac.confirmed);
-    assertRange(this, 0, this.ac.words.length, 0);
-  });
+    test('empty string', function() {
+      this.refine('');
 
-  test('some', function() {
-    this.refine('some');
+      assert(!this.ac.confirmed);
+      assertRange(this, 0, this.ac.words.length, 0);
+    });
 
-    assert(!this.ac.confirmed);
-    assertRange(this, 2, this.ac.words.length - 1, 3);
-  });
+    test('some', function() {
+      this.refine('some');
 
-  test('confirmable', function() {
-    this.refine('somet');
+      assert(!this.ac.confirmed);
+      assertRange(this, 2, this.ac.words.length - 1, 3);
+    });
 
-    assert.equal(this.ac.confirmed, 'something');
-    assertRange(this, 2, 3);
-  });
+    test('confirmable', function() {
+      this.refine('somet');
 
-  test('decrement', function() {
-    this.refine('o');
-    this.refine('');
+      assert.equal(this.ac.confirmed, 'something');
+      assertRange(this, 2, 3);
+    });
 
-    assertRange(this, 0, this.ac.words.length, 0);
-  });
+    test('decrement', function() {
+      this.refine('o');
+      this.refine('');
 
-  test('other => empty => some', function() {
-    this.refine('other');
-    this.refine('');
-    this.refine('some');
+      assertRange(this, 0, this.ac.words.length, 0);
+    });
 
-    assertRange(this, 2, this.ac.words.length - 1, 3);
-  });
+    test('other => empty => some', function() {
+      this.refine('other');
+      this.refine('');
+      this.refine('some');
 
-  test('some => empty', function() {
-    this.refine('some');
-    this.refine('');
+      assertRange(this, 2, this.ac.words.length - 1, 3);
+    });
 
-    assertRange(this, 0, this.ac.words.length);
+    test('some => empty', function() {
+      this.refine('some');
+      this.refine('');
+
+      assertRange(this, 0, this.ac.words.length);
+    });
   });
 
   function assertRange(self, left, right, hiddenCnt) {

--- a/test/templates/test/test_helper.js
+++ b/test/templates/test/test_helper.js
@@ -9,9 +9,11 @@
       event.initEvent(eventName, true, true); // type, bubbles, cancelable
       el.dispatchEvent(event);
     },
-    keyDown: function(keyCode) {
+    keyDown: function(keyCode, options) {
+      options = options || {};
       return {
         keyCode: keyCode,
+        shiftKey: options.shiftKey,
         preventDefault: function() {},
         stopPropagation: function() {}
       };


### PR DESCRIPTION
This pull request is to trim suggested keywords in auto-completion. The main changes are as follow:

* Add `Autocomplete#trim` method
  - to show just five elements (for now)
  - and it shows `...` in prefix and suffix if the list includes trimmed items
* Test the trimming method

r? @gsamokovarov Could you review this pull request, please? :octocat:  

Thank you.