### PR TITLE
Show hinting information on auto-completing

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -76,6 +76,10 @@ Autocomplete.prototype.item = function(x) {
   return this.view.children[x+1];
 };
 
+Autocomplete.prototype.selectedWord = function() {
+  return this.left <= this.current && this.current < this.right && this.words[this.current];
+}
+
 Autocomplete.prototype.onFinished = function(callback) {
   this.onFinishedCallback = callback;
   if (this.confirmed) callback(this.confirmed);
@@ -473,9 +477,8 @@ REPLConsole.prototype.renderInput = function() {
   // Clear the current input.
   removeAllChildren(this.promptDisplay);
 
-  var promptCursor = document.createElement('span');
-  promptCursor.className = "console-cursor";
   var before, current, after;
+  var center = document.createElement('span');
 
   if (this._caretPos < 0) {
     before = this._input;
@@ -491,9 +494,12 @@ REPLConsole.prototype.renderInput = function() {
   }
 
   this.promptDisplay.appendChild(document.createTextNode(before));
-  promptCursor.appendChild(document.createTextNode(current));
-  this.promptDisplay.appendChild(promptCursor);
+  this.promptDisplay.appendChild(center);
   this.promptDisplay.appendChild(document.createTextNode(after));
+
+  var hint = this.autocomplete && !this.autocomplete.confirmed && this.autocomplete.selectedWord();
+  addClass(center, hint ? 'console-hint' : 'console-cursor');
+  center.appendChild(document.createTextNode(hint ? hint.substr(this.getCurrentWord().length) : current));
 };
 
 REPLConsole.prototype.writeOutput = function(output) {
@@ -551,6 +557,7 @@ REPLConsole.prototype.onNavigateHistory = function(offset) {
  */
 REPLConsole.prototype.onKeyDown = function(ev) {
   if (this.autocomplete && this.autocomplete.onKeyDown(ev)) {
+    this.renderInput();
     ev.preventDefault();
     ev.stopPropagation();
     return;

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -191,9 +191,9 @@ Autocomplete.prototype.refine = function(prefix) {
 
 Autocomplete.prototype.finish = function() {
   if (this.left <= this.current && this.current < this.right) {
-    if (this.onFinishedCallback) this.onFinishedCallback(this.words[this.current]);
-    this.removeView();
     this.confirmed = this.words[this.current];
+    if (this.onFinishedCallback) this.onFinishedCallback(this.confirmed);
+    this.removeView();
   } else {
     this.cancel();
   }
@@ -450,6 +450,7 @@ REPLConsole.prototype.setInput = function(input, caretPos) {
   if (input == null) return; // keep value if input is undefined
   this._caretPos = caretPos === undefined ? input.length : caretPos;
   this._input = input;
+  if (this.autocomplete && !this.autocomplete.confirmed) this.autocomplete.refine(input);
   this.renderInput();
 };
 
@@ -598,7 +599,6 @@ REPLConsole.prototype.onKeyDown = function(ev) {
     case 8:
       // Delete
       this.deleteAtCurrent();
-      if (this.autocomplete) this.autocomplete.refine(this.getCurrentWord());
       ev.preventDefault();
       break;
     default:
@@ -631,7 +631,6 @@ REPLConsole.prototype.onKeyPress = function(ev) {
   if (ev.ctrlKey || ev.metaKey) { return; }
   var keyCode = ev.keyCode || ev.which;
   this.insertAtCurrent(String.fromCharCode(keyCode));
-  if (this.autocomplete) this.autocomplete.refine(this.getCurrentWord());
   ev.stopPropagation();
   ev.preventDefault();
 };

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -82,7 +82,7 @@ Autocomplete.prototype.selectedWord = function() {
 
 Autocomplete.prototype.onFinished = function(callback) {
   this.onFinishedCallback = callback;
-  if (this.confirmed) callback(this.confirmed);
+  if (this.confirmed || this.canceled) callback(this.confirmed);
 };
 
 Autocomplete.prototype.onKeyDown = function(ev) {
@@ -187,9 +187,11 @@ Autocomplete.prototype.refine = function(prefix) {
   }
   self.trim(this.current, false);
 
-  if (self.left + 1 >= self.right) {
+  if (self.left + 1 == self.right) {
     self.current = self.left;
     self.finish();
+  } else if (self.left == self.right) {
+    self.cancel();
   }
 };
 
@@ -205,6 +207,7 @@ Autocomplete.prototype.finish = function() {
 
 Autocomplete.prototype.cancel = function() {
   if (this.onFinishedCallback) this.onFinishedCallback();
+  this.canceled = true;
   this.removeView();
 };
 
@@ -540,7 +543,7 @@ REPLConsole.prototype.onTabKey = function() {
     self.autocomplete = new Autocomplete(obj['context'], self.getCurrentWord());
     self.inner.appendChild(self.autocomplete.view);
     self.autocomplete.onFinished(function(word) {
-      self.swapCurrentWord(word);
+      if (word) self.swapCurrentWord(word);
       self.autocomplete = false;
     });
     self.scrollToBottom();

--- a/lib/web_console/templates/style.css.erb
+++ b/lib/web_console/templates/style.css.erb
@@ -16,6 +16,7 @@
 .console .console-message.auto-complete .keyword.selected { background: #FFF; color: #000; }
 .console .console-message.auto-complete .hidden { display: none; }
 .console .console-message.auto-complete .trimmed { display: none; }
+.console .console-hint { text-decoration: underline; color: #099; }
 .console .console-focus .console-cursor { background: #FEFEFE; color: #333; font-weight: bold; }
 .console .resizer { background: #333; width: 100%; height: 4px; cursor: ns-resize; }
 .console .console-actions { padding-right: 3px; }


### PR DESCRIPTION
This pull request is to show hinting information on auto-completing, it allows us to check selected word on the prompt of web-console. There are three things in this change:

* Call `Autocomplete#refine` on `REPLConsole#setInput`
* Show hinting information on auto-completing
* Improve cancel handling for auto-completion

Thanks.