### PR TITLE
Some improvements around the auto-completion feature

### DIFF
--- a/lib/web_console/context.rb
+++ b/lib/web_console/context.rb
@@ -26,14 +26,14 @@ module WebConsole
       ]
 
       def global
-        GLOBAL_OBJECTS.map { |cmd| eval(cmd) }.flatten
+        GLOBAL_OBJECTS.map { |cmd| eval(cmd) }
       end
 
       def local(input)
         [
           eval("#{input}.methods").map { |m| "#{input}.#{m}" },
           eval("#{input}.constants").map { |c| "#{input}::#{c}" },
-        ].flatten
+        ]
       end
 
       def eval(cmd)

--- a/lib/web_console/context.rb
+++ b/lib/web_console/context.rb
@@ -5,37 +5,34 @@ module WebConsole
       @binding = binding
     end
 
-    # Extracts entire objects which can be called by the current session unless the objpath is present.
-    # Otherwise, it extracts methods and constants of the object specified by the objpath.
-    def extract(objpath)
-      if objpath.present?
-        local(objpath)
-      else
-        global
-      end
+    # Extracts entire objects which can be called by the current session unless
+    # the inputs is present.
+    #
+    # Otherwise, it extracts methods and constants of the object specified by
+    # the input.
+    def extract(input = nil)
+      input.present? ? local(input) : global
     end
 
     private
 
       GLOBAL_OBJECTS = [
-        'global_variables',
-        'local_variables',
         'instance_variables',
-        'instance_methods',
-        'class_variables',
+        'local_variables',
         'methods',
+        'class_variables',
         'Object.constants',
-        'Kernel.methods',
+        'global_variables'
       ]
 
       def global
-        SortedSet.new GLOBAL_OBJECTS.map { |cmd| eval(cmd) }.flatten
+        GLOBAL_OBJECTS.map { |cmd| eval(cmd) }.flatten
       end
 
-      def local(objpath)
-        SortedSet.new [
-          eval("#{objpath}.methods").map { |m| "#{objpath}.#{m}" },
-          eval("#{objpath}.constants").map { |c| "#{objpath}::#{c}" },
+      def local(input)
+        [
+          eval("#{input}.methods").map { |m| "#{input}.#{m}" },
+          eval("#{input}.constants").map { |c| "#{input}::#{c}" },
         ].flatten
       end
 

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -103,7 +103,11 @@ module WebConsole
 
       def update_repl_session(id, request)
         json_response_with_session(id, request) do |session|
-          { output: session.eval(request.params[:input]), context: session.context(request.params[:context]) }
+          if input = request.params[:input]
+            { output: session.eval(input) }
+          elsif input = request.params[:context]
+            { context: session.context(input) }
+          end
         end
       end
 

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -129,6 +129,8 @@ Autocomplete.prototype.onKeyDown = function(ev) {
     case 27: // Esc
       this.cancel();
       return true;
+    case 37: case 38: case 39: case 40: // disable using arrow keys on completing
+      return true;
   }
 
   return false;
@@ -414,6 +416,7 @@ REPLConsole.prototype.install = function(container) {
   this.outer = consoleOuter;
   this.inner = findChild(this.outer, 'console-inner');
   this.clipboard = findChild(container, 'clipboard');
+  this.suggestWait = 1500;
   this.newPromptBox();
   this.insertCss();
 
@@ -482,12 +485,63 @@ REPLConsole.prototype.removeCaretFromPrompt = function() {
   this.setInput(this._input, -1);
 };
 
+REPLConsole.prototype.getSuggestion = function(keyword) {
+  var self = this;
+
+  function show(found) {
+    if (!found) return;
+    var hint = self.promptDisplay.childNodes[1];
+    hint.className = 'console-hint';
+    hint.dataset.keyword = found;
+    hint.innerText = found.substr(self.suggestKeyword.length);
+    // clear hinting information after timeout in a few time 
+    if (self.suggestTimeout) clearTimeout(self.suggestTimeout);
+    self.suggestTimeout = setTimeout(function() { self.renderInput() }, self.suggestWait);
+  }
+
+  function find(context) {
+    var k = self.suggestKeyword;
+    for (var i = 0; i < context.length; ++i) if (context[i].substr(0, k.length) === k) {
+      if (context[i] === k) return;
+      return context[i];
+    }
+  }
+
+  function request(keyword, callback) {
+    self.contextRequest(keyword, function(err, res) {
+      if (err) throw new Error(err);
+      var c = flatten(res['context']);
+      c.sort();
+      callback(c);
+    });
+  }
+
+  self.suggestKeyword = keyword;
+  var input = getContext(keyword);
+  if (keyword.length - input.length < 3) return;
+
+  if (self.suggestInput !== input) {
+    self.suggestInput = input;
+    request(keyword, function(c) {
+      show(find(self.suggestContext = c));
+    });
+  } else if (self.suggestContext) {
+    show(find(self.suggestContext));
+  }
+};
+
+REPLConsole.prototype.getHintKeyword = function() {
+  var hint = this.promptDisplay.childNodes[1];
+  return hint.className === 'console-hint' && hint.dataset.keyword;
+};
+
 REPLConsole.prototype.setInput = function(input, caretPos) {
   if (input == null) return; // keep value if input is undefined
   this._caretPos = caretPos === undefined ? input.length : caretPos;
   this._input = input;
   if (this.autocomplete) this.autocomplete.refine(this.getCurrentWord());
   this.renderInput();
+  if (!this.autocomplete && input.length == this._caretPos) this.getSuggestion(this.getCurrentWord());
 };
 
 /**
@@ -509,9 +563,8 @@ REPLConsole.prototype.renderInput = function() {
   // Clear the current input.
   removeAllChildren(this.promptDisplay);
 
-  var promptCursor = document.createElement('span');
-  promptCursor.className = "console-cursor";
   var before, current, after;
+  var center = document.createElement('span');
 
   if (this._caretPos < 0) {
     before = this._input;
@@ -527,9 +580,12 @@ REPLConsole.prototype.renderInput = function() {
   }
 
   this.promptDisplay.appendChild(document.createTextNode(before));
-  promptCursor.appendChild(document.createTextNode(current));
-  this.promptDisplay.appendChild(promptCursor);
+  this.promptDisplay.appendChild(center);
   this.promptDisplay.appendChild(document.createTextNode(after));
+
+  var hint = this.autocomplete && this.autocomplete.getSelectedWord();
+  addClass(center, hint ? 'console-hint' : 'console-cursor');
+  center.appendChild(document.createTextNode(hint ? hint.substr(this.getCurrentWord().length) : current));
 };
 
 REPLConsole.prototype.writeOutput = function(output) {
@@ -560,6 +616,12 @@ REPLConsole.prototype.onEnterKey = function() {
 REPLConsole.prototype.onTabKey = function() {
   var self = this;
 
+  var hintKeyword;
+  if (hintKeyword = self.getHintKeyword()) {
+    self.swapCurrentWord(hintKeyword);
+    return;
+  }
+
   if (self.autocomplete) return;
   self.autocomplete = new Autocomplete([]);
 
@@ -585,6 +647,7 @@ REPLConsole.prototype.onNavigateHistory = function(offset) {
  */
 REPLConsole.prototype.onKeyDown = function(ev) {
   if (this.autocomplete && this.autocomplete.onKeyDown(ev)) {
+    this.renderInput();
     ev.preventDefault();
     ev.stopPropagation();
     return;

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -44,36 +44,52 @@ function CommandStorage() {
   }
 }
 
-function Autocomplete(words, prefix) {
-  this.words = words;
+function Autocomplete(_words, prefix) {
+  this.words = prepareWords(_words);
   this.current = -1;
   this.left = 0; // [left, right)
-  this.right = words.length;
+  this.right = this.words.length;
   this.confirmed = false;
-  this.prefix = createSpan('...');
-  this.suffix = createSpan('...');
 
-  function createSpan(label) {
+  function createSpan(label, className) {
     var el = document.createElement('span');
+    addClass(el, className);
     el.innerText = label;
     return el;
   }
 
+  function prepareWords(words) {
+    // convert into an object with priority and element
+    var res = new Array(words.length);
+    for (var i = 0, ind = 0; i < words.length; ++i) {
+      res[i] = new Array(words[i].length);
+      for (var j = 0; j < words[i].length; ++j) {
+        res[i][j] = {
+          word: words[i][j],
+          priority: i,
+          element: createSpan(words[i][j], 'trimmed keyword')
+        };
+      }
+    }
+    // flatten and sort by alphabetical order to refine incrementally
+    res = flatten(res);
+    res.sort(function(a, b) { return a.word == b.word ? 0 : (a.word < b.word ? -1 : 1); });
+    for (var i = 0; i < res.length; ++i) res[i].element.dataset.index = i;
+    return res;
+  }
+
   this.view = document.createElement('pre');
   addClass(this.view, 'auto-complete console-message');
-
-  this.view.appendChild(this.prefix);
-  for (var key in this.words) {
-    this.view.appendChild(createSpan(this.words[key]));
-  }
-  this.view.appendChild(this.suffix);
-  addClass(this.view.children, 'trimmed keyword');
+  this.view.appendChild(this.prefix = createSpan('...', 'trimmed keyword'));
+  this.view.appendChild(this.stage = document.createElement('span'));
+  this.elements = this.stage.children;
+  this.view.appendChild(this.suffix = createSpan('...', 'trimmed keyword'));
 
   this.refine(prefix || '');
 }
 
-Autocomplete.prototype.item = function(x) {
-  return this.view.children[x+1];
+Autocomplete.prototype.getSelectedWord = function() {
+  return this.lastSelected && this.lastSelected.innerText;
 };
 
 Autocomplete.prototype.onFinished = function(callback) {
@@ -83,11 +99,11 @@ Autocomplete.prototype.onFinished = function(callback) {
 
 Autocomplete.prototype.onKeyDown = function(ev) {
   var self = this;
+  if (!this.elements.length) return;
 
   function move(nextCurrent) {
-    if (! self.words.length) return;
-    if (0 <= self.current && self.current < self.words.length) removeClass(self.item(self.current), 'selected');
-    addClass(self.item(nextCurrent), 'selected');
+    if (self.lastSelected) removeClass(self.lastSelected, 'selected');
+    addClass(self.lastSelected = self.elements[nextCurrent], 'selected');
     self.trim(self.current, true);
     self.trim(nextCurrent, false);
     self.current = nextCurrent;
@@ -96,9 +112,9 @@ Autocomplete.prototype.onKeyDown = function(ev) {
   switch (ev.keyCode) {
     case 9: // Tab
       if (ev.shiftKey) { // move back
-        move(self.current - 1 < self.left ? self.right - 1 : self.current - 1);
+        move(this.current - 1 < 0 ? this.elements.length - 1 : this.current - 1);
       } else { // move next
-        move(self.current + 1 >= self.right ? self.left : self.current + 1);
+        move(this.current + 1 >= this.elements.length ? 0 : this.current + 1);
       }
       return true;
     case 13: // Enter
@@ -116,38 +132,42 @@ Autocomplete.prototype.trim = function(from, needToTrim) {
   var self = this;
   var num = 5;
 
-  if (this.right - this.left > num) {
-    (this.left < from ? removeClass : addClass)(this.prefix, 'trimmed');
-    (from + num < this.right? removeClass : addClass)(this.suffix, 'trimmed');
+  if (this.elements.length > num) {
+    (0 < from ? removeClass : addClass)(this.prefix, 'trimmed');
+    (from + num < this.elements.length ? removeClass : addClass)(this.suffix, 'trimmed');
   } else {
     addClass(this.prefix, 'trimmed');
     addClass(this.suffix, 'trimmed');
   }
 
   function iterate(x) {
-    for (var i = 0; i < num; ++i, ++x) if (self.left <= x && x < self.right) {
-      toggleClass(self.item(x), 'trimmed');
+    for (var i = 0; i < num; ++i, ++x) if (0 <= x && x < self.elements.length) {
+      toggleClass(self.elements[x], 'trimmed');
     }
   }
 
   var toggleClass = needToTrim ? addClass : removeClass;
-  if (from < this.left) {
-    iterate(this.left);
-  } else if (from + num - 1 >= this.right) {
-    iterate(this.right - num);
+  if (from < 0) {
+    iterate(0);
+  } else if (from + num - 1 >= this.elements.length) {
+    iterate(this.elements.length - num);
   } else {
     iterate(from);
   }
 };
 
 Autocomplete.prototype.refine = function(prefix) {
+  if (this.confirmed) return;
   var inc = !this.prev || (prefix.length >= this.prev.length);
   this.prev = prefix;
   var self = this;
 
+  function remove(parent, child) {
+    if (parent == child.parentNode) parent.removeChild(child);
+  }
+
   function toggle(el) {
-    if (hasClass(el, 'selected')) removeClass(el, 'selected');
-    return inc ? addClass(el, 'hidden') : removeClass(el, 'hidden');
+    return inc ? remove(self.stage, el) : self.stage.appendChild(el);
   }
 
   function startsWith(str, prefix) {
@@ -155,22 +175,18 @@ Autocomplete.prototype.refine = function(prefix) {
   }
 
   function moveRight(l, r) {
-    while (l < r && inc !== startsWith(self.words[l], prefix)) {
-      toggle(self.item(l));
-      ++ l;
-    }
+    while (l < r && inc !== startsWith(self.words[l].word, prefix)) toggle(self.words[l++].element);
     return l;
   }
 
   function moveLeft(l, r) {
-    while (l < r - 1 && inc !== startsWith(self.words[r - 1], prefix)) {
-      toggle(self.item(r - 1));
-      -- r;
-    }
+    while (l < r - 1 && inc !== startsWith(self.words[r-1].word, prefix)) toggle(self.words[--r].element);
     return r;
   }
 
-  self.trim(self.current, true);
+  self.trim(self.current, true); // reset trimming
+
+  // Refine the range of words having same prefix
   if (inc) {
     self.left = moveRight(self.left, self.right);
     self.right = moveLeft(self.left, self.right);
@@ -178,22 +194,39 @@ Autocomplete.prototype.refine = function(prefix) {
     self.left = moveLeft(-1, self.left);
     self.right = moveRight(self.right, self.words.length);
   }
-  if (this.current < this.left || this.current >= this.right) {
-    this.current = this.left - 1;
-  }
-  self.trim(this.current, false);
 
-  if (self.left + 1 >= self.right) {
-    self.current = self.left;
+  // Render elements with sorting by scope groups
+  var words = this.words.slice(this.left, this.right);
+  words.sort(function(a, b) { return a.priority == b.priority ? (a.word < b.word ? -1 : 1) : (a.priority < b.priority ? -1 : 1); });
+  removeAllChildren(this.elements);
+  for (var i = 0; i < words.length; ++i) {
+    this.stage.appendChild(words[i].element);
+  }
+
+  // Keep a previous selected element if the refined range includes the element
+  if (this.lastSelected && this.left <= this.lastSelected.dataset.index && this.lastSelected.dataset.index < this.right) {
+    this.current = Array.prototype.indexOf.call(this.elements, this.lastSelected);
+    this.trim(this.current, false);
+  } else {
+    if (this.lastSelected) removeClass(this.lastSelected, 'selected');
+    this.lastSelected = null;
+    this.current = -1;
+    this.trim(0, false);
+  }
+
+  if (self.left + 1 == self.right) {
+    self.current = 0;
     self.finish();
+  } else if (self.left == self.right) {
+    self.cancel();
   }
 };
 
 Autocomplete.prototype.finish = function() {
-  if (this.left <= this.current && this.current < this.right) {
-    if (this.onFinishedCallback) this.onFinishedCallback(this.words[this.current]);
+  if (0 <= this.current && this.current < this.elements.length) {
+    this.confirmed = this.elements[this.current].innerText;
+    if (this.onFinishedCallback) this.onFinishedCallback(this.confirmed);
     this.removeView();
-    this.confirmed = this.words[this.current];
   } else {
     this.cancel();
   }
@@ -447,6 +480,7 @@ REPLConsole.prototype.setInput = function(input, caretPos) {
   if (input == null) return; // keep value if input is undefined
   this._caretPos = caretPos === undefined ? input.length : caretPos;
   this._input = input;
+  if (this.autocomplete) this.autocomplete.refine(this.getCurrentWord());
   this.renderInput();
 };
 
@@ -493,7 +527,6 @@ REPLConsole.prototype.renderInput = function() {
 };
 
 REPLConsole.prototype.writeOutput = function(output) {
-  if (this.autocomplete) return;
   var consoleMessage = document.createElement('pre');
   consoleMessage.className = "console-message";
   consoleMessage.innerHTML = escapeHTML(output);
@@ -503,7 +536,6 @@ REPLConsole.prototype.writeOutput = function(output) {
 };
 
 REPLConsole.prototype.writeError = function(output) {
-  if (this.autocomplete) return;
   var consoleMessage = this.writeOutput(output);
   addClass(consoleMessage, "error-message");
   return consoleMessage;
@@ -595,7 +627,6 @@ REPLConsole.prototype.onKeyDown = function(ev) {
     case 8:
       // Delete
       this.deleteAtCurrent();
-      if (this.autocomplete) this.autocomplete.refine(this.getCurrentWord());
       ev.preventDefault();
       break;
     default:
@@ -628,7 +659,6 @@ REPLConsole.prototype.onKeyPress = function(ev) {
   if (ev.ctrlKey || ev.metaKey) { return; }
   var keyCode = ev.keyCode || ev.which;
   this.insertAtCurrent(String.fromCharCode(keyCode));
-  if (this.autocomplete) this.autocomplete.refine(this.getCurrentWord());
   ev.stopPropagation();
   ev.preventDefault();
 };
@@ -804,4 +834,8 @@ function getContext(s) {
   var moduleOp = s.lastIndexOf('::');
   var x = methodOp > moduleOp ? methodOp : moduleOp;
   return x !== -1 ? s.substr(0, x) : '';
+}
+
+function flatten(arrays) {
+  return Array.prototype.concat.apply([], arrays);
 }

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -110,6 +110,12 @@ Autocomplete.prototype.onKeyDown = function(ev) {
   }
 
   switch (ev.keyCode) {
+    case 69:
+      if (ev.ctrlKey) {
+        move(this.current + 1 >= this.elements.length ? 0 : this.current + 1);
+        return true;
+      }
+      return false;
     case 9: // Tab
       if (ev.shiftKey) { // move back
         move(this.current - 1 < 0 ? this.elements.length - 1 : this.current - 1);
@@ -585,6 +591,13 @@ REPLConsole.prototype.onKeyDown = function(ev) {
   }
 
   switch (ev.keyCode) {
+    case 69:
+      // Ctrl-E
+      if (ev.ctrlKey) {
+        this.onTabKey();
+        ev.preventDefault();
+      }
+      break;
     case 9:
       // Tab
       this.onTabKey();
@@ -672,6 +685,11 @@ REPLConsole.prototype.deleteAtCurrent = function() {
     var before = this._input.substring(0, caretPos);
     var after = this._input.substring(this._caretPos, this._input.length);
     this.setInput(before + after, caretPos);
+
+    if (!this._input) {
+      this.autocomplete && this.autocomplete.cancel();
+      this.autocomplete = false;
+    }
   }
 };
 

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -239,6 +239,16 @@ REPLConsole.prototype.getSessionUrl = function(path) {
   return parts.join('/').replace(/([^:]\/)\/+/g, '$1');
 };
 
+REPLConsole.prototype.contextRequest = function(keyword, callback) {
+  putRequest(this.getSessionUrl(), 'context=' + getContext(keyword), function(xhr) {
+    if (xhr.status == 200) {
+      callback(null, JSON.parse(xhr.responseText));
+    } else {
+      callback(xhr.statusText);
+    }
+  });
+};
+
 REPLConsole.prototype.commandHandle = function(line, callback) {
   var self = this;
   var params = 'input=' + encodeURIComponent(line);
@@ -262,19 +272,6 @@ REPLConsole.prototype.commandHandle = function(line, callback) {
     } else {
       return xhr.status + ' ' + xhr.statusText;
     }
-  }
-
-  function getContext() {
-    var s = self.getCurrentWord();
-    var methodOp = s.lastIndexOf('.');
-    var moduleOp = s.lastIndexOf('::');
-    var x = methodOp > moduleOp ? methodOp : moduleOp;
-    if (x !== -1) return s.substr(0, x);
-  }
-
-  if (this.autocomplete) {
-    var c = getContext();
-    params += c ? '&context=' + c : '';
   }
 
   putRequest(self.getSessionUrl(), params, function(xhr) {
@@ -528,8 +525,8 @@ REPLConsole.prototype.onTabKey = function() {
   if (self.autocomplete) return;
   self.autocomplete = new Autocomplete([]);
 
-  self.commandHandle("nil", function(ok, obj) {
-    if (!ok) return self.autocomplete = false;
+  self.contextRequest(self.getCurrentWord(), function(err, obj) {
+    if (err) return self.autocomplete = false;
     self.autocomplete = new Autocomplete(obj['context'], self.getCurrentWord());
     self.inner.appendChild(self.autocomplete.view);
     self.autocomplete.onFinished(function(word) {
@@ -799,4 +796,12 @@ if (typeof exports === 'object') {
   exports.REPLConsole = REPLConsole;
 } else {
   window.REPLConsole = REPLConsole;
+}
+
+// Split string by module operators of ruby
+function getContext(s) {
+  var methodOp = s.lastIndexOf('.');
+  var moduleOp = s.lastIndexOf('::');
+  var x = methodOp > moduleOp ? methodOp : moduleOp;
+  return x !== -1 ? s.substr(0, x) : '';
 }

--- a/lib/web_console/templates/style.css.erb
+++ b/lib/web_console/templates/style.css.erb
@@ -16,6 +16,7 @@
 .console .console-message.auto-complete .keyword.selected { background: #FFF; color: #000; }
 .console .console-message.auto-complete .hidden { display: none; }
 .console .console-message.auto-complete .trimmed { display: none; }
+.console .console-hint { color: #096; }
 .console .console-focus .console-cursor { background: #FEFEFE; color: #333; font-weight: bold; }
 .console .resizer { background: #333; width: 100%; height: 4px; cursor: ns-resize; }
 .console .console-actions { padding-right: 3px; }

--- a/test/templates/config.ru
+++ b/test/templates/config.ru
@@ -43,7 +43,7 @@ end
 
 map "/mock/repl_sessions/result" do
   headers = { 'Content-Type' => 'application/json' }
-  body = [ { output: '=> "fake-result"\n', context: [ :something, :somewhat, :somewhere ] }.to_json ]
+  body = [ { output: '=> "fake-result"\n', context: [ [ :something, :somewhat, :somewhere ] ] }.to_json ]
   run lambda { |env| [ 200, headers, body ] }
 end
 

--- a/test/templates/test/auto_complete_test.js
+++ b/test/templates/test/auto_complete_test.js
@@ -1,11 +1,7 @@
 suite('Autocomplete', function() {
   suite('Trimming', function() {
     test('prefix and suffix stands for that the list includes trimmed elements', function() {
-      var ac = new Autocomplete(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
-      assert.equal(ac.prefix, ac.view.children[0]);
-      assert.equal(ac.prefix.innerText, ac.view.children[0].innerText);
-      assert.equal(ac.suffix, ac.view.children[ac.words.length + 1]);
-      assert.equal(ac.suffix.innerText, ac.view.children[ac.words.length + 1].innerText);
+      var ac = new Autocomplete([['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']]);
       assertTrimmed(ac.prefix);
       assertNotTrimmed(ac.suffix);
 
@@ -25,13 +21,13 @@ suite('Autocomplete', function() {
       assertNotTrimmed(ac.suffix);
 
       // ... D E F G H
-      for (var i = 0; i <= ac.words.indexOf('D'); ++i) ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      for (var i = 0; i < 4; ++i) ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
       assertNotTrimmed(ac.prefix);
       assertTrimmed(ac.suffix);
     });
 
     test('prefix and suffix are always trimmed if the list has few items', function() {
-      var ac = new Autocomplete(['A', 'B', 'C']);
+      var ac = new Autocomplete([['A', 'B', 'C']]);
       assertTrimmed(ac.prefix);
       assertTrimmed(ac.suffix);
 
@@ -52,7 +48,7 @@ suite('Autocomplete', function() {
     });
 
     test('shows only five elements after the current element', function() {
-      var ac = new Autocomplete(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+      var ac = new Autocomplete([['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']]);
 
       // A B C D E ...
       assert.equal(-1, ac.current);
@@ -78,10 +74,10 @@ suite('Autocomplete', function() {
     });
 
     test('keeps to show the last five elements', function() {
-      var ac = new Autocomplete(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+      var ac = new Autocomplete([['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']]);
 
       // G: D E F G H
-      for (var i = 0; i <= ac.words.indexOf('G'); ++i) ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
+      for (var i = 0; i < 7; ++i) ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
       assert.equal(6, ac.current);
       assertClass(ac, 0, 3, 'trimmed');
       assertNotClass(ac, 3, ac.words.length, 'trimmed');
@@ -104,24 +100,22 @@ suite('Autocomplete', function() {
       assertNotClass(ac, 3, ac.words.length, 'trimmed');
     });
 
-    test('shows five elements if prefix is passed', function() {
-      var ac = new Autocomplete(['A', 'B1', 'B2', 'B3', 'C'], 'B');
-      assert.equal(0, ac.current);
-      assertClass(ac, 0, 1, 'trimmed');
-      assertNotClass(ac, 1, 4, 'trimmed');
-      assertClass(ac, 4, ac.words.length, 'trimmed');
+    test('handles five elements with prefix', function() {
+      var ac = new Autocomplete([['A', 'B1', 'B2', 'B3', 'C']], 'B');
+      assert.equal(-1, ac.current);
+      assert.equal(3, ac.elements.length);
+      assertNotClass(ac, 0, 3, 'trimmed');
 
       ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
-      assert.equal(1, ac.current);
-      assertClass(ac, 0, 1, 'trimmed');
-      assertNotClass(ac, 1, 4, 'trimmed');
-      assertClass(ac, 4, ac.words.length, 'trimmed');
+      assert.equal(0, ac.current);
+      assert.equal(3, ac.elements.length);
+      assertNotClass(ac, 0, 3, 'trimmed');
     });
   });
 
   suite('Refinements', function() {
     setup(function() {
-      this.ac = new Autocomplete(['other', 'other2', 'something', 'somewhat', 'somewhere', 'test']);
+      this.ac = new Autocomplete([['other', 'other2', 'something', 'somewhat', 'somewhere', 'test']]);
       this.refine = function(prefix) { this.ac.refine(prefix); };
     });
 
@@ -136,7 +130,7 @@ suite('Autocomplete', function() {
       this.refine('some');
 
       assert(!this.ac.confirmed);
-      assertRange(this, 2, this.ac.words.length - 1, 3);
+      assert.equal(3, this.ac.elements.length);
     });
 
     test('confirmable', function() {
@@ -158,7 +152,7 @@ suite('Autocomplete', function() {
       this.refine('');
       this.refine('some');
 
-      assertRange(this, 2, this.ac.words.length - 1, 3);
+      assert.equal(3, this.ac.elements.length);
     });
 
     test('some => empty', function() {
@@ -181,13 +175,13 @@ suite('Autocomplete', function() {
 
   function assertClass(ac, left, right, className) {
     for (var i = left; i < right; ++i) {
-      assert.ok(hasClass(ac.item(i), className), i + '-th element shuold have ' + className);
+      assert.ok(hasClass(ac.elements[i], className), i + '-th element shuold have ' + className);
     }
   }
 
   function assertNotClass(ac, left, right, className) {
     for (var i = left; i < right; ++i) {
-      assert.notOk(hasClass(ac.item(i), className), i + '-th element should not have ' + className);
+      assert.notOk(hasClass(ac.elements[i], className), i + '-th element should not have ' + className);
     }
   }
 

--- a/test/templates/test/auto_complete_test.js
+++ b/test/templates/test/auto_complete_test.js
@@ -111,6 +111,23 @@ suite('Autocomplete', function() {
       assert.equal(3, ac.elements.length);
       assertNotClass(ac, 0, 3, 'trimmed');
     });
+
+    test('can select item with the Ctrl-E key', function() {
+      var ac = new Autocomplete([['A', 'B', 'C']]);
+      assert.equal(-1, ac.current);
+
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_E, { ctrlKey: true }));
+      assert.equal(0, ac.current);
+
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_E, { ctrlKey: true }));
+      assert.equal(1, ac.current);
+
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_E, { ctrlKey: true }));
+      assert.equal(2, ac.current);
+
+      ac.onKeyDown(TestHelper.keyDown(TestHelper.KEY_E, { ctrlKey: true }));
+      assert.equal(0, ac.current);
+    });
   });
 
   suite('Refinements', function() {

--- a/test/templates/test/repl_console_test.js
+++ b/test/templates/test/repl_console_test.js
@@ -153,4 +153,40 @@ suite('REPLCosnole', function() {
       }, 100);
     });
   });
+
+  suite('Auto Suggestion', function() {
+    test('shows first matched word in current context', function(done) {
+      var c = this.console;
+      c.setInput('some');
+      setTimeout(function() {
+        assert.match(c.promptDisplay.innerText, /^something/);
+        done();
+      }, 100);
+    });
+
+    test('hides automatically in a few seconds', function(done) {
+      var c = this.console;
+      c.suggestWait = 200;
+      c.setInput('some');
+
+      assert.equal('some\u00A0', c.promptDisplay.innerText);
+      setTimeout(function() {
+        assert.match(c.promptDisplay.innerText, /something/);
+        setTimeout(function() {
+          assert.equal('some\u00A0', c.promptDisplay.innerText);
+          done();
+        }, 200);
+      }, 100);
+    });
+
+    test('inserts the current word if tab key is pressed', function() {
+      var c = this.console;
+      c.setInput('some');
+
+      setTimeout(function() {
+        c.onKeyDown(TestHelper.KeyDown(TestHelper.KEY_TAB));
+        assert.equal('something', c._input);
+      }, 100);
+    });
+  });
 });

--- a/test/templates/test/test_helper.js
+++ b/test/templates/test/test_helper.js
@@ -4,6 +4,7 @@
   var TestHelper = {
     KEY_TAB: 9,
     KEY_ENTER: 13,
+    KEY_E: 69,
     triggerEvent: function(el, eventName) {
       var event = document.createEvent("MouseEvents");
       event.initEvent(eventName, true, true); // type, bubbles, cancelable
@@ -13,6 +14,7 @@
       options = options || {};
       return {
         keyCode: keyCode,
+        ctrlKey: options.ctrlKey,
         shiftKey: options.shiftKey,
         preventDefault: function() {},
         stopPropagation: function() {}

--- a/test/web_console/context_test.rb
+++ b/test/web_console/context_test.rb
@@ -4,25 +4,30 @@ module WebConsole
   class ContextTest < ActiveSupport::TestCase
     test '#extract(empty) includes local variables' do
       local_var = 'local'
-      assert Context.new(binding).extract('').include?(:local_var)
+      assert context(binding).include?(:local_var)
     end
 
     test '#extract(empty) includes instance variables' do
       @instance_var = 'instance'
-      assert Context.new(binding).extract('').include?(:@instance_var)
+      assert context(binding).include?(:@instance_var)
     end
 
     test '#extract(empty) includes global variables' do
       $global_var = 'global'
-      assert Context.new(binding).extract('').include?(:$global_var)
+      assert context(binding).include?(:$global_var)
     end
 
     test '#extract(obj) returns methods' do
-      assert Context.new(binding).extract('Rails').include?('Rails.root')
+      assert context(binding, 'Rails').include?('Rails.root')
     end
 
     test '#extract(obj) returns constants' do
-      assert Context.new(binding).extract('WebConsole').include?('WebConsole::Middleware')
+      assert context(binding, 'WebConsole').include?('WebConsole::Middleware')
     end
+
+    private
+      def context(b, o = '')
+        Context.new(b).extract(o).flatten
+      end
   end
 end

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -154,6 +154,17 @@ module WebConsole
       assert_equal("=> #{line}\n", JSON.parse(response.body)["output"])
     end
 
+    test 'can return context information by passing a context param' do
+      hello = 'world'
+      session = Session.new([binding])
+      Session.stubs(:from).returns(session)
+
+      get '/'
+      put "/repl_sessions/#{session.id}", xhr: true, params: { context: '' }
+
+      assert_includes(JSON.parse(response.body)["context"], local_variables.map(&:to_s))
+    end
+
     test 'unavailable sessions respond to the user with a message' do
       put '/repl_sessions/no_such_session', xhr: true, params: { input: '__LINE__' }
 


### PR DESCRIPTION
### I. Summary :octocat: 

This pull request is to improve the auto-completion featuere. This pull request includes the changes of #216 and #217 (Thanks :bow: ) and the auto-suggests mode using the auto-completing functions on the frontend in order to help us typing commands (see also below example GIFs).

### II. Changes

* Sort the input by scope groups (ported from #217 )
* Add `REPLConsole#contextRequest` separated from `REPLConsole#commandHandle`
  - ref: 6e68765
* Divide a response from Middleware into two responses ("normal output" and "context output")
  - to reduce the length of the normal output responses
  - ref: 6e68765
* Flatten the context information on the front-end
* Sort items for auto-completions by priority
  - ref: 9fb1066
* Add auto-suggests mode
  - to help typing commands
  - ref: 4ab5b51
* Add some tests for the above things
* And add some minor fixes the logic around the auto-completing feature

### III. Examples

#### 1. The auto-suggests mode

Start the auto-completion automatically after the 3rd character press, it will hint the "proper" one.

![Auto suggesting mode](http://i.imgur.com/YOMIsMv.gif)

#### 2. Sort by priority in the auto-completing feature

For example, it shows local variables in front of other methods.

![Sort by priority in the auto-completing feature](http://i.imgur.com/ytS4Qvu.gif)

--

r? @gsamokovarov Sorry for the delay and thanks for your ideas. Could you review this pull request? It is fine for me to do it when you have free time.

Thank you.