### PR TITLE
ignore error in parsing remote address

### DIFF
--- a/lib/web_console/whitelist.rb
+++ b/lib/web_console/whitelist.rb
@@ -15,6 +15,8 @@ module WebConsole
 
     def include?(network)
       @networks.any? { |whitelist| whitelist.include?(network.to_s) }
+    rescue IPAddr::InvalidAddressError
+      false
     end
 
     def to_s

--- a/test/web_console/whitelist_test.rb
+++ b/test/web_console/whitelist_test.rb
@@ -31,6 +31,12 @@ module WebConsole
         assert_includes whitelisted_ips, "192.168.0.#{n}"
       end
     end
+    
+    test 'ignore an unix socket' do
+      whitelisted_ips = whitelist('8.8.8.8')
+
+      assert_not_includes whitelisted_ips, 'unix:'
+    end
 
     test 'can be represented in a human readable form' do
       assert_includes whitelist.to_s, '127.0.0.0/127.255.255.255, ::1'


### PR DESCRIPTION
`whitelist.include?(network.to_s)` raises an error in parsing remote address in case the address is not IPv4 or IPv6 format.

I met the case on an environment that the rails-server is used as upstream of nginx proxy through an unix socket. At that time, the remote address is "unix:".