### PR TITLE
Add note on breaking change. Rails 4 no longer supported.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -5,6 +5,7 @@
 ## 3.4.0
 
 * [#205](https://github.com/rails/web-console/pull/205) Introduce autocompletion ([@sh19910711])
+* Breaking Change: Drop support for Rails 4.
 
 ## 3.3.1
 


### PR DESCRIPTION
Adding a note to the changelog on `3.4.`. Rails 4 no longer supported. See full `Bundler` output for details.

```
➜  rails4app git:(master) ✗ bundle update web-console
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies.......
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    web-console (= 3.4.0) was resolved to 3.4.0, which depends on
      activemodel (>= 5.0) was resolved to 5.0.0, which depends on
        activesupport (= 5.0.0)

    web-console (= 3.4.0) was resolved to 3.4.0, which depends on
      railties (>= 5.0) was resolved to 5.0.0.1, which depends on
        activesupport (= 5.0.0.1)
Bundler could not find compatible versions for gem "rack":
  In Gemfile:
    web-console (= 3.4.0) was resolved to 3.4.0, which depends on
      railties (>= 5.0) was resolved to 5.0.0, which depends on
        actionpack (= 5.0.0) was resolved to 5.0.0, which depends on
          rack (~> 2.0)

    better_errors (= 2.1.1) was resolved to 2.1.1, which depends on
      rack (>= 0.9.0)

    heroku_rails_deflate (= 1.0.3) was resolved to 1.0.3, which depends on
      rack (>= 1.4.5)

    omniauth (= 1.6.1) was resolved to 1.6.1, which depends on
      rack (< 3, >= 1.6.2)

    web-console (= 3.4.0) was resolved to 3.4.0, which depends on
      railties (>= 5.0) was resolved to 5.0.0, which depends on
        actionpack (= 5.0.0) was resolved to 5.0.0, which depends on
          rack-test (~> 0.6.3) was resolved to 0.6.3, which depends on
            rack (>= 1.0)

    resque (= 1.27.2) was resolved to 1.27.2, which depends on
      sinatra (>= 0.9.2) was resolved to 1.4.8, which depends on
        rack (~> 1.5)

    resque (= 1.27.2) was resolved to 1.27.2, which depends on
      vegas (~> 0.1.2) was resolved to 0.1.11, which depends on
        rack (>= 1.0.0)

```