### PR TITLE
Avoid early loading of actionview

### DIFF
--- a/lib/web_console/extensions.rb
+++ b/lib/web_console/extensions.rb
@@ -20,12 +20,12 @@ module Kernel
   end
 end
 
-module ActionDispatch
-  class DebugExceptions
-    def render_exception_with_web_console(request, exception)
-      render_exception_without_web_console(request, exception).tap do
+module WebConsole
+  module DebugExceptions
+    def render_exception(request, exception)
+      super(request, exception).tap do
         backtrace_cleaner = request.get_header('action_dispatch.backtrace_cleaner')
-        error = ExceptionWrapper.new(backtrace_cleaner, exception).exception
+        error = ActionDispatch::ExceptionWrapper.new(backtrace_cleaner, exception).exception
 
         # Get the original exception if ExceptionWrapper decides to follow it.
         Thread.current[:__web_console_exception] = error
@@ -38,8 +38,5 @@ module ActionDispatch
         end
       end
     end
-
-    alias_method :render_exception_without_web_console, :render_exception
-    alias_method :render_exception, :render_exception_with_web_console
   end
 end

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -66,5 +66,11 @@ module WebConsole
     initializer 'i18n.load_path' do
       config.i18n.load_path.concat(Dir[File.expand_path('../locales/*.yml', __FILE__)])
     end
+
+    initializer 'web_console.patch_debug_exception_middleware' do |app|
+      app.config.after_initialize do
+        ActionDispatch::DebugExceptions.prepend DebugExceptions
+      end
+    end
   end
 end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/28538, which describes the problem that this PR solves.

Note that there were 2 separate issues causing the early loading of ActionView, one of which was fixed there and one here.  Neither one depends on the other.