### PR TITLE
Let WebConsole.logger respect Rails.logger

### DIFF
--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -21,8 +21,9 @@ module WebConsole
     autoload :DoubleRenderError
   end
 
-  mattr_accessor :logger
-  @@logger = ActiveSupport::Logger.new($stderr)
+  def self.logger
+    Rails.logger || (@logger ||= ActiveSupport::Logger.new($stderr))
+  end
 end
 
 require 'web_console/railtie'

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -8,10 +8,6 @@ module WebConsole
     initializer 'web_console.initialize' do
       require 'bindex'
       require 'web_console/extensions'
-
-      if logger = ::Rails.logger
-        WebConsole.logger = logger
-      end
     end
 
     initializer 'web_console.development_only' do


### PR DESCRIPTION
We used to set WebConsole.logger during Bundle.require time, which
happened to be way earlier than when Rails.logger was initialized, so we
always ended up with `STDERR` logger. In this change, we let
`WebConsole.logger` to dynamically call `Rails.logger`, which will let
us use it once initialized. If by the time we try to log something,
`Rails.logger` isn't initialized or is explicitly set to nothing, we'll
still fallback to the `STDERR` logging.