### PR TITLE
Fix Issue #40

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -732,7 +732,7 @@ REPLConsole.prototype.onKeyDown = function(ev) {
  */
 REPLConsole.prototype.onKeyPress = function(ev) {
   // Only write to the console if it's a single key press.
-  if (ev.ctrlKey || ev.metaKey) { return; }
+  if (ev.ctrlKey && !ev.altKey || ev.metaKey) { return; }
   var keyCode = ev.keyCode || ev.which;
   this.insertAtCurrent(String.fromCharCode(keyCode));
   ev.stopPropagation();


### PR DESCRIPTION
Special characters combinations on non US keyboards are marked as ev.ctrlKey == true and ev.altKey == true (eg. 'AltGr' + '(' => '[' on fr-FR keyboard).