### PR TITLE
Update for frozen-string-literal friendliness.

### DIFF
--- a/lib/web-console.rb
+++ b/lib/web-console.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'web_console'

--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/dependencies/autoload'
 require 'active_support/logger'
 

--- a/lib/web_console/context.rb
+++ b/lib/web_console/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # A context lets you get object names related to the current session binding.
   class Context

--- a/lib/web_console/errors.rb
+++ b/lib/web_console/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # The base class for every Web Console related error.
   Error = Class.new(StandardError)

--- a/lib/web_console/evaluator.rb
+++ b/lib/web_console/evaluator.rb
@@ -25,7 +25,7 @@ module WebConsole
       def format_exception(exc)
         backtrace = cleaner.clean(Array(exc.backtrace) - caller)
 
-        format = "#{exc.class.name}: #{exc}\n"
+        format = "#{exc.class.name}: #{exc}\n".dup
         format << backtrace.map { |trace| "\tfrom #{trace}\n" }.join
         format
       end

--- a/lib/web_console/evaluator.rb
+++ b/lib/web_console/evaluator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # Simple Ruby code evaluator.
   #

--- a/lib/web_console/exception_mapper.rb
+++ b/lib/web_console/exception_mapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class ExceptionMapper
     def initialize(exception)

--- a/lib/web_console/extensions.rb
+++ b/lib/web_console/extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kernel
   module_function
 

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/string/strip'
 
 module WebConsole

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/railtie'
 
 module WebConsole

--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # Web Console tailored request object.
   class Request < ActionDispatch::Request

--- a/lib/web_console/response.rb
+++ b/lib/web_console/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # A response object that writes content before the closing </body> tag, if
   # possible.

--- a/lib/web_console/session.rb
+++ b/lib/web_console/session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # A session lets you persist an +Evaluator+ instance in memory associated
   # with multiple bindings.

--- a/lib/web_console/tasks/extensions.rake
+++ b/lib/web_console/tasks/extensions.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :ext do
   rootdir = Pathname('extensions')
 

--- a/lib/web_console/tasks/templates.rake
+++ b/lib/web_console/tasks/templates.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :templates do
   desc 'Run tests for templates'
   task test: [ :daemonize, :npm, :rackup, :wait, :mocha, :kill, :exit ]

--- a/lib/web_console/template.rb
+++ b/lib/web_console/template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # A facade that handles template rendering and composition.
   #

--- a/lib/web_console/testing/erb_precompiler.rb
+++ b/lib/web_console/testing/erb_precompiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'web_console/testing/helper'
 require 'web_console/testing/fake_middleware'
 

--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'action_view'
 require 'web_console'
 require 'web_console/testing/helper'

--- a/lib/web_console/testing/helper.rb
+++ b/lib/web_console/testing/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   module Testing
     module Helper

--- a/lib/web_console/version.rb
+++ b/lib/web_console/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   VERSION = '3.5.1'
 end

--- a/lib/web_console/view.rb
+++ b/lib/web_console/view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class View < ActionView::Base
     # Execute a block only on error pages.

--- a/lib/web_console/whiny_request.rb
+++ b/lib/web_console/whiny_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   # Noisy wrapper around +Request+.
   #

--- a/lib/web_console/whitelist.rb
+++ b/lib/web_console/whitelist.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ipaddr'
 
 module WebConsole

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/test/dummy/app/controllers/controller_helper_test_controller.rb
+++ b/test/dummy/app/controllers/controller_helper_test_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ControllerHelperTestController < ApplicationController
   def index
     @instance_variable = "Helper Test"

--- a/test/dummy/app/controllers/exception_test_controller.rb
+++ b/test/dummy/app/controllers/exception_test_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ExceptionTestController < ApplicationController
   def index
     test = "Test"

--- a/test/dummy/app/controllers/helper_error_controller.rb
+++ b/test/dummy/app/controllers/helper_error_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HelperErrorController < ApplicationController
   def index
   end

--- a/test/dummy/app/controllers/helper_test_controller.rb
+++ b/test/dummy/app/controllers/helper_test_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HelperTestController < ApplicationController
   def index
     @helper_test = "Helper Test"

--- a/test/dummy/app/controllers/model_test_controller.rb
+++ b/test/dummy/app/controllers/model_test_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ModelTestController < ApplicationController
   def index
     LocalModel.new.work

--- a/test/dummy/app/controllers/tests_controller.rb
+++ b/test/dummy/app/controllers/tests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestsController < ApplicationController
   def render_console_ontop_of_text
     render text: '<h1 id="greeting">Hello World</h1>'

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 require "active_model/railtie"

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy/config/initializers/backtrace_silencers.rb
+++ b/test/dummy/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy/config/initializers/filter_parameter_logging.rb
+++ b/test/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/dummy/config/initializers/inflections.rb
+++ b/test/dummy/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/dummy/config/initializers/mime_types.rb
+++ b/test/dummy/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy/config/initializers/secret_token.rb
+++ b/test/dummy/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.

--- a/test/dummy/config/initializers/session_store.rb
+++ b/test/dummy/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'

--- a/test/dummy/config/initializers/wrap_parameters.rb
+++ b/test/dummy/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   root to: "exception_test#index"
 

--- a/test/support/scenarios/bad_custom_error_scenario.rb
+++ b/test/support/scenarios/bad_custom_error_scenario.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class BadCustomErrorScenario
     class Error < StandardError

--- a/test/support/scenarios/basic_nested_scenario.rb
+++ b/test/support/scenarios/basic_nested_scenario.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class BasicNestedScenario
     def call

--- a/test/support/scenarios/custom_error_scenario.rb
+++ b/test/support/scenarios/custom_error_scenario.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class CustomErrorScenario
     Error = Class.new(StandardError)

--- a/test/support/scenarios/eval_nested_scenario.rb
+++ b/test/support/scenarios/eval_nested_scenario.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class EvalNestedScenario
     def call

--- a/test/support/scenarios/flat_scenario.rb
+++ b/test/support/scenarios/flat_scenario.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class FlatScenario
     def call

--- a/test/support/scenarios/reraised_scenario.rb
+++ b/test/support/scenarios/reraised_scenario.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebConsole
   class ReraisedScenario
     def call

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 case RUBY_ENGINE
 when 'ruby', 'rbx'
   require 'simplecov'

--- a/test/web_console/context_test.rb
+++ b/test/web_console/context_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/evaluator_test.rb
+++ b/test/web_console/evaluator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/exception_mapper_test.rb
+++ b/test/web_console/exception_mapper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/extensions_test.rb
+++ b/test/web_console/extensions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'web_console/extensions'
 

--- a/test/web_console/helper_test.rb
+++ b/test/web_console/helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/integration_test.rb
+++ b/test/web_console/integration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole
@@ -5,37 +7,37 @@ module WebConsole
     test 'Exception#bindings returns all the bindings of where the error originated' do
       exc = FlatScenario.new.call
 
-      assert_equal 4, exc.bindings.first.eval('__LINE__')
+      assert_equal 6, exc.bindings.first.eval('__LINE__')
     end
 
     test 'Exception#bindings returns all the bindings for a custom error' do
       exc = CustomErrorScenario.new.call
 
-      assert_equal 6, exc.bindings.first.eval('__LINE__')
+      assert_equal 8, exc.bindings.first.eval('__LINE__')
     end
 
     test 'Exception#bindings returns all the bindings for a bad custom error' do
       exc = BadCustomErrorScenario.new.call
 
-      assert_equal 11, exc.bindings.first.eval('__LINE__')
+      assert_equal 13, exc.bindings.first.eval('__LINE__')
     end
 
     test 'Exception#bindings goes down the stack' do
       exc = BasicNestedScenario.new.call
 
-      assert_equal 12, exc.bindings.first.eval('__LINE__')
+      assert_equal 14, exc.bindings.first.eval('__LINE__')
     end
 
     test 'Exception#bindings inside of an eval' do
       exc = EvalNestedScenario.new.call
 
-      assert_equal 12, exc.bindings.first.eval('__LINE__')
+      assert_equal 14, exc.bindings.first.eval('__LINE__')
     end
 
     test "re-raising doesn't lose Exception#bindings information" do
       exc = ReraisedScenario.new.call
 
-      assert_equal 4, exc.bindings.first.eval('__LINE__')
+      assert_equal 6, exc.bindings.first.eval('__LINE__')
     end
 
     test 'Exception#bindings is empty when exception is still not raised' do

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/railtie_test.rb
+++ b/test/web_console/railtie_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/session_test.rb
+++ b/test/web_console/session_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/whiny_request_test.rb
+++ b/test/web_console/whiny_request_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole

--- a/test/web_console/whitelist_test.rb
+++ b/test/web_console/whitelist_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module WebConsole


### PR DESCRIPTION
One minor change that keeps all tests green when frozen string literals are in play in MRI 2.4+.

I've done this testing by adding the pragma comment to all Ruby files in lib and test locally, but have not included those changes in this PR. I'm happy to add them in if you'd like, I just don't want to presume whether that's preferred or not.