### PR TITLE
Rescue ActionDispatch::RemoteIp::IpSpoofAttackError

### DIFF
--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -21,6 +21,8 @@ module WebConsole
     # Determines the remote IP using our much stricter whitelist.
     def strict_remote_ip
       GetSecureIp.new(self, whitelisted_ips).to_s
+    rescue ActionDispatch::RemoteIp::IpSpoofAttackError
+      '[Spoofed]'
     end
 
     # Returns whether the request is acceptable.

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -44,6 +44,12 @@ module WebConsole
       assert_not req.from_whitelisted_ip?
     end
 
+    test '#from_whitelisted_ip? is falsy for spoofed IPs' do
+      req = request('http://example.com', 'HTTP_CLIENT_IP' => '127.0.0.1', 'HTTP_X_FORWARDED_FOR' => '127.0.0.0')
+
+      assert_not req.from_whitelisted_ip?
+    end
+
     test '#acceptable? is truthy for current version' do
       req = xhr('http://example.com', 'HTTP_ACCEPT' => "#{Mime[:web_console_v2]}")
 

--- a/test/web_console/whiny_request_test.rb
+++ b/test/web_console/whiny_request_test.rb
@@ -12,6 +12,13 @@ module WebConsole
       assert_not req.from_whitelisted_ip?
     end
 
+    test '#from_whitelisted_ip? is falsy for spoofed IPs' do
+      WebConsole.logger.expects(:info)
+      req = request('http://example.com', 'HTTP_CLIENT_IP' => '127.0.0.1', 'HTTP_X_FORWARDED_FOR' => '127.0.0.0')
+
+      assert_not req.from_whitelisted_ip?
+    end
+
     private
 
       def request(*args)


### PR DESCRIPTION
`#from_whitelisted_ip?` should return `false` instead of raising an `ActionDispatch::RemoteIp::IpSpoofAttackError` exception.

This fixes an issue introduced by fc321fd8ebc49f4b1f1b0e9201e96a89a276f061, where spoofed-ip requests will always raise an exception in the Rack middleware stack at `WebConsole::Middleware`, effectively ignoring the `config.action_dispatch.ip_spoofing_check` setting whenever the Web Console is in the application stack.

With this PR, access to the Web Console will still be denied to spoofed-ip requests, but the request will continue to be passed up the stack to `ActionDispatch::RemoteIp`, where the app will still raise `IpSpoofAttackError` unless `config.action_dispatch.ip_spoofing_check` is `false`.

Fixes rails/rails#32379.