### PR TITLE
Fix truncated body in exception view

### DIFF
--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -34,7 +34,7 @@ module WebConsole
           headers["X-Web-Console-Mount-Point"] = mount_point
 
           # Remove any previously set Content-Length header because we modify
-          # the body. Otherwise the response will will be truncated.
+          # the body. Otherwise the response will be truncated.
           # Someone will calculate it again, at least the application server.
           headers.delete("Content-Length")
 

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -33,6 +33,11 @@ module WebConsole
           headers["X-Web-Console-Session-Id"] = session.id
           headers["X-Web-Console-Mount-Point"] = mount_point
 
+          # Remove any previously set Content-Length header because we modify
+          # the body. Otherwise the response will will be truncated.
+          # Someone will calculate it again, at least the application server.
+          headers.delete("Content-Length")
+
           template = Template.new(env, session)
           body = Injector.new(body).inject(template.render("index"))
         end


### PR DESCRIPTION
ActionPack's `debug_exceptions` will calculate the Content-Length of the rendered body. [See implementation here.](https://github.com/rails/rails/blob/2929d165c23f0d3976425a8e70de77847cc4b872/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L180)

After injecting the console into the body, there will be a mismatch between the Content-Length Header and the actual response body. So the browser will truncate the output.

![image](https://user-images.githubusercontent.com/4227520/39302823-4415ded6-4954-11e8-8565-a1fb157729b2.png)

As a solution the Content-Length Header will be deleted, as the application server will calculate the Content-Length again, if it isn't present already.