### PR TITLE
Warn on double render instead of disallowing it

### DIFF
--- a/lib/web_console/extensions.rb
+++ b/lib/web_console/extensions.rb
@@ -7,11 +7,11 @@ module Kernel
   #
   # If +binding+ isn't explicitly given it will default to the binding of the
   # previous frame. E.g. the one that invoked +console+.
-  #
-  # Raises DoubleRenderError if a double +console+ invocation per request is
-  # detected.
   def console(binding = Bindex.current_bindings.second)
-    raise WebConsole::DoubleRenderError if Thread.current[:__web_console_binding]
+    if previous = Thread.current[:__web_console_binding]
+      location = "#{previous.eval('__FILE__')}:#{previous.eval('__LINE__')}".remove(Rails.root.to_s)
+      WebConsole.logger.warn "Kernel#console is already called in:\n↳ #{location}"
+    end
 
     Thread.current[:__web_console_binding] = binding
 

--- a/test/web_console/helper_test.rb
+++ b/test/web_console/helper_test.rb
@@ -73,12 +73,12 @@ module WebConsole
       assert_select "#console"
     end
 
-    test "raises an error when trying to spawn a console more than once" do
+    test "warns when trying to spawn a console more than once" do
       @app = Middleware.new(MultipleConsolesApplication.new)
 
-      assert_raises(DoubleRenderError) do
-        get "/", params: nil, headers: { "CONTENT_TYPE" => "text/html" }
-      end
+      WebConsole.logger.expects(:warn)
+
+      get "/", params: nil, headers: { "CONTENT_TYPE" => "text/html" }
     end
 
     test "doesn't hijack current view" do


### PR DESCRIPTION
Getting the exception while just putting a `Kernel#console` after
`Kernel#console` while tracking the error may get you out of the debug
flow state. I like this new behavior, but it has drawbacks. The problem
with it is that you may not get the binding that you wanted, but the
binding of the last evaluated `Kernel#console`. I'll test a release with
it.