### PR TITLE
Add support for nested exceptions

### DIFF
--- a/lib/web_console/exception_mapper.rb
+++ b/lib/web_console/exception_mapper.rb
@@ -2,9 +2,28 @@
 
 module WebConsole
   class ExceptionMapper
+    attr_reader :exc
+
+    def self.follow(exc)
+      mappers = [new(exc)]
+
+      while cause = (cause || exc).cause
+        mappers << new(cause)
+      end
+
+      mappers
+    end
+
+    def self.find_binding(mappers, exception_object_id)
+      mappers.detect do |exception_mapper|
+        exception_mapper.exc.object_id == exception_object_id.to_i
+      end || mappers.first
+    end
+
     def initialize(exception)
       @backtrace = exception.backtrace
       @bindings = exception.bindings
+      @exc = exception
     end
 
     def first

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -110,7 +110,7 @@ module WebConsole
 
       def change_stack_trace(id, request)
         json_response_with_session(id, request) do |session|
-          session.switch_binding_to(request.params[:frame_id])
+          session.switch_binding_to(request.params[:frame_id], request.params[:exception_object_id])
 
           { ok: true }
         end

--- a/lib/web_console/session.rb
+++ b/lib/web_console/session.rb
@@ -31,9 +31,9 @@ module WebConsole
       # storage.
       def from(storage)
         if exc = storage[:__web_console_exception]
-          new(ExceptionMapper.new(exc))
+          new(ExceptionMapper.follow(exc))
         elsif binding = storage[:__web_console_binding]
-          new([binding])
+          new([[binding]])
         end
       end
     end
@@ -41,10 +41,11 @@ module WebConsole
     # An unique identifier for every REPL.
     attr_reader :id
 
-    def initialize(bindings)
+    def initialize(exception_mappers)
       @id = SecureRandom.hex(16)
-      @bindings = bindings
-      @evaluator = Evaluator.new(@current_binding = bindings.first)
+
+      @exception_mappers = exception_mappers
+      @evaluator         = Evaluator.new(@current_binding = exception_mappers.first.first)
 
       store_into_memory
     end
@@ -59,8 +60,10 @@ module WebConsole
     # Switches the current binding to the one at specified +index+.
     #
     # Returns nothing.
-    def switch_binding_to(index)
-      @evaluator = Evaluator.new(@current_binding = @bindings[index.to_i])
+    def switch_binding_to(index, exception_object_id)
+      bindings = ExceptionMapper.find_binding(@exception_mappers, exception_object_id)
+
+      @evaluator = Evaluator.new(@current_binding = bindings[index.to_i])
     end
 
     # Returns context of the current binding

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -871,9 +871,13 @@ REPLConsole.prototype.scrollToBottom = function() {
 };
 
 // Change the binding of the console.
-REPLConsole.prototype.switchBindingTo = function(frameId, callback) {
+REPLConsole.prototype.switchBindingTo = function(frameId, exceptionObjectId, callback) {
   var url = this.getSessionUrl('trace');
   var params = "frame_id=" + encodeURIComponent(frameId);
+
+  if (exceptionObjectId) {
+    params = params + "&exception_object_id=" + encodeURIComponent(exceptionObjectId);
+  }
 
   var _this = this;
   postRequest(url, params, function() {

--- a/lib/web_console/templates/error_page.js.erb
+++ b/lib/web_console/templates/error_page.js.erb
@@ -8,9 +8,10 @@ for (var i = 0; i < traceFrames.length; i++) {
     e.preventDefault();
     var target = e.target;
     var frameId = target.dataset.frameId;
+    var exceptionObjectId = target.dataset.exceptionObjectId;
 
     // Change the binding of the console.
-    changeBinding(frameId, function() {
+    changeBinding(frameId, exceptionObjectId, function() {
       // Rails already handles toggling the select class
       selectedFrame = target;
       return target.innerHTML;
@@ -22,8 +23,8 @@ for (var i = 0; i < traceFrames.length; i++) {
 }
 
 // Change the binding of the current session and prompt the user.
-function changeBinding(frameId, callback) {
-  REPLConsole.currentSession.switchBindingTo(frameId, callback);
+function changeBinding(frameId, exceptionObjectId, callback) {
+  REPLConsole.currentSession.switchBindingTo(frameId, exceptionObjectId, callback);
 }
 
 function changeSourceExtract(frameId) {


### PR DESCRIPTION
This PR depends on https://github.com/rails/rails/pull/32410.

This PR adds support for nested exceptions that is being discussed in the upstream Rails. The idea is to add an object scope using the `exception_object_id` and pass it to the web console session along with the `frame_id`, so the session will be able to switch the binding to the specified frame in the appropriate exception.

Obviously, there needs to be some test overage around this as this is touching the core functionality of the gem. But please let me know if there is any feedback.

 * [x] Add more test coverage
