### PR TITLE
Test against latest jruby release, 9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.4.4
   - 2.5.1
+  - jruby-9.2.0.0
   - ruby-head
   - jruby-head
 
@@ -21,6 +22,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: jruby-9.2.0.0
     - env: TEST_SUITE=templates:test
   include:
     - env: TEST_SUITE=templates:test


### PR DESCRIPTION
https://github.com/rails/web-console/commit/ff81317b153d0fb62639849576a1b15e3d373260 removed 9.1.8.0 from the TravisCI matrix because of not being installable. Since then, 9.2.0.0 was released, which is MRI 2.5-compatible, so I guess it should be added back?