### PR TITLE
Fix initializer "web_console.permissions"

### DIFF
--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -53,7 +53,7 @@ module WebConsole
     end
 
     initializer "web_console.permissions" do
-      if permissions = config.web_console.permissions || config.web_console.whitelisted_ips
+      if permissions = config.web_console.whitelisted_ips || config.web_console.permissions
         Request.permissions = Permissions.new(permissions)
       end
     end

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -5,7 +5,6 @@ require "rails/railtie"
 module WebConsole
   class Railtie < ::Rails::Railtie
     config.web_console = ActiveSupport::OrderedOptions.new
-    config.web_console.permissions = %w( 127.0.0.1 ::1 )
 
     initializer "web_console.initialize" do
       require "bindex"
@@ -53,9 +52,8 @@ module WebConsole
     end
 
     initializer "web_console.permissions" do
-      if permissions = config.web_console.whitelisted_ips || config.web_console.permissions
-        Request.permissions = Permissions.new(permissions)
-      end
+      permissions = config.web_console.permissions || config.web_console.whitelisted_ips
+      Request.permissions = Permissions.new(permissions)
     end
 
     initializer "web_console.whiny_requests" do

--- a/test/web_console/railtie_test.rb
+++ b/test/web_console/railtie_test.rb
@@ -21,6 +21,18 @@ module WebConsole
       end
     end
 
+    test "config.permissions sets whitelisted networks by whitelisted_ips" do
+      new_uninitialized_app do |app|
+        app.config.web_console.whitelisted_ips = %w( 172.16.0.0/12 192.168.0.0/16 )
+        app.initialize!
+
+        1.upto(255).each do |n|
+          assert_includes Request.permissions, "172.16.0.#{n}"
+          assert_includes Request.permissions, "192.168.0.#{n}"
+        end
+      end
+    end
+
     test "config.permissions always includes localhost" do
       new_uninitialized_app do |app|
         app.config.web_console.permissions = "8.8.8.8"


### PR DESCRIPTION
config.web_console.permissions is always exists.
As a result, config.web_console.whitelisted_ips never used.