### PR TITLE
Increase timeout on paste

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -760,7 +760,7 @@ REPLConsole.prototype.onKeyDown = function(ev) {
         _this.addToInput(_this.clipboard.value);
         _this.clipboard.value = "";
         _this.clipboard.blur();
-      }, 10);
+      }, 100);
     }
   }
 


### PR DESCRIPTION
Seems that the timeout of 10ms is too short for pasting on MacOS. I arbitrarily picked 100ms and it works much more consistently.

Should fix #36 