### PR TITLE
Defer registering Interceptor until ActionView has been loaded.

### DIFF
--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -10,7 +10,11 @@ module WebConsole
       require "bindex"
       require "web_console/extensions"
 
-      ActionDispatch::DebugExceptions.register_interceptor(Interceptor)
+      # Interceptor references ActionView::Template::Error.
+      # Defer registering it until ActionView has been loaded.
+      ActiveSupport.on_load(:action_view) do
+        ActionDispatch::DebugExceptions.register_interceptor(Interceptor)
+      end
     end
 
     initializer "web_console.development_only" do


### PR DESCRIPTION
Interceptor references ActionView::Template::Error. To prevent
prematurely loading ActionView the Interceptor should be registered
after ActionView has been loaded.

This could help move the following issue forward: https://github.com/rails/rails/pull/38024