### PR TITLE
Fix Content-Length for rack >= 2.1.0

### DIFF
--- a/lib/web_console/injector.rb
+++ b/lib/web_console/injector.rb
@@ -13,9 +13,11 @@ module WebConsole
     end
 
     def inject(content)
-      # Remove any previously set Content-Length header because we modify
-      # the body. Otherwise the response will be truncated.
-      @headers.delete("Content-Length")
+      # Set Content-Length header to the size of the current body
+      # + the extra content. Otherwise the response will be truncated.
+      if @headers["Content-Length"]
+        @headers["Content-Length"] = @body.bytesize + content.bytesize
+      end
 
       [
         if position = @body.rindex("</body>")

--- a/test/web_console/injector_test.rb
+++ b/test/web_console/injector_test.rb
@@ -28,11 +28,11 @@ module WebConsole
       assert_equal [ [ "foobar" ], {} ], Injector.new(body, {}).inject("bar")
     end
 
-    test "deletes the Content-Length header" do
+    test "updates the Content-Length header" do
       body = [ "foo" ]
       headers = { "Content-Length" => 3 }
 
-      assert_equal [ [ "foobar" ], {} ], Injector.new(body, headers).inject("bar")
+      assert_equal [ [ "foobar" ], { "Content-Length" => 6 } ], Injector.new(body, headers).inject("bar")
     end
   end
 end

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -89,6 +89,7 @@ module WebConsole
       @app = Middleware.new(Application.new(response_content_length: 7))
 
       get "/", params: nil
+
       assert_equal(response.body.size, response.headers["Content-Length"].to_i)
     end
 


### PR DESCRIPTION
Since rack 2.1.0 the Content-Length header is no longer updated for
if the body argument isn't a string. This was done for performance
reasons. It is recommended to set Content-Length header in the
middlewate instead.

See: https://github.com/rack/rack/issues/1472#issuecomment-574362342

This fixes the build.