### PR TITLE
Use config.web_console.allowed_ips

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,7 +66,7 @@ By default, only requests coming from IPv4 and IPv6 localhosts are allowed.
 `config.web_console.permissions` lets you control which IP's have access to
 the console.
 
-You can whitelist single IP's or whole networks. Say you want to share your
+You can allow single IP's or whole networks. Say you want to share your
 console with `192.168.0.100`:
 
 ```ruby
@@ -75,7 +75,7 @@ class Application < Rails::Application
 end
 ```
 
-If you want to whitelist the whole private network:
+If you want to allow the whole private network:
 
 ```ruby
 Rails.application.configure do

--- a/lib/web_console/permissions.rb
+++ b/lib/web_console/permissions.rb
@@ -4,7 +4,7 @@ require "ipaddr"
 
 module WebConsole
   class Permissions
-    # IPv4 and IPv6 localhost should be always whitelisted.
+    # IPv4 and IPv6 localhost should be always allowed.
     ALWAYS_PERMITTED_NETWORKS = %w( 127.0.0.0/8 ::1 )
 
     def initialize(networks = nil)

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -52,8 +52,23 @@ module WebConsole
     end
 
     initializer "web_console.permissions" do
-      permissions = config.web_console.permissions || config.web_console.whitelisted_ips
+      permissions = web_console_permissions
       Request.permissions = Permissions.new(permissions)
+    end
+
+    def web_console_permissions
+      case
+      when config.web_console.permissions
+        config.web_console.permissions
+      when config.web_console.allowed_ips
+        config.web_console.allowed_ips
+      when config.web_console.whitelisted_ips
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          The config.web_console.whitelisted_ips is deprecated and will be ignored in future release of web_console.
+          Please use config.web_console.allowed_ips instead.
+        MSG
+        config.web_console.whitelisted_ips
+      end
     end
 
     initializer "web_console.whiny_requests" do

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -140,7 +140,7 @@ module WebConsole
       assert_select "#console", 0
     end
 
-    test "doesn't render console from non whitelisted IP" do
+    test "doesn't render console from not allowed IP" do
       Thread.current[:__web_console_binding] = binding
       Request.stubs(:permissions).returns(IPAddr.new("127.0.0.1"))
 

--- a/test/web_console/permissions_test.rb
+++ b/test/web_console/permissions_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 module WebConsole
   class PermissionsTest < ActiveSupport::TestCase
-    test "localhost is always whitelisted" do
+    test "localhost is always allowed" do
       permissions = permit("8.8.8.8")
 
       assert_includes permissions, "127.0.0.1"

--- a/test/web_console/railtie_test.rb
+++ b/test/web_console/railtie_test.rb
@@ -9,7 +9,7 @@ module WebConsole
       Middleware.mount_point = "/__web_console"
     end
 
-    test "config.permissions sets whitelisted networks" do
+    test "config.permissions sets allowed networks" do
       new_uninitialized_app do |app|
         app.config.web_console.permissions = %w( 172.16.0.0/12 192.168.0.0/16 )
         app.initialize!
@@ -21,9 +21,9 @@ module WebConsole
       end
     end
 
-    test "config.permissions sets whitelisted networks by whitelisted_ips" do
+    test "config.permissions sets allowed networks by allowed_ips" do
       new_uninitialized_app do |app|
-        app.config.web_console.whitelisted_ips = %w( 172.16.0.0/12 192.168.0.0/16 )
+        app.config.web_console.allowed_ips = %w( 172.16.0.0/12 192.168.0.0/16 )
         app.initialize!
 
         1.upto(255).each do |n|

--- a/test/web_console/request_test.rb
+++ b/test/web_console/request_test.rb
@@ -8,37 +8,37 @@ module WebConsole
       Request.stubs(:permissions).returns(IPAddr.new("127.0.0.1"))
     end
 
-    test "#permitted? is falsy for blacklisted IPs" do
+    test "#permitted? is falsy for not allowed IPs" do
       req = request("http://example.com", "REMOTE_ADDR" => "0.0.0.0")
 
       assert_not req.permitted?
     end
 
-    test "#permitted? is truthy for whitelisted IPs" do
+    test "#permitted? is truthy for allowed IPs" do
       req = request("http://example.com", "REMOTE_ADDR" => "127.0.0.1")
 
       assert req.permitted?
     end
 
-    test "#permitted? is truthy for whitelisted IPs via whitelisted proxies" do
+    test "#permitted? is truthy for allowed IPs via allowed proxies" do
       req = request("http://example.com", "REMOTE_ADDR" => "127.0.0.1", "HTTP_X_FORWARDED_FOR" => "127.0.0.0")
 
       assert req.permitted?
     end
 
-    test "#permitted? is falsy for blacklisted IPs via whitelisted proxies" do
+    test "#permitted? is falsy for not allowed IPs via allowed proxies" do
       req = request("http://example.com", "REMOTE_ADDR" => "127.0.0.1", "HTTP_X_FORWARDED_FOR" => "0.0.0.0")
 
       assert_not req.permitted?
     end
 
-    test "#permitted? is falsy for lying blacklisted IPs via whitelisted proxies" do
+    test "#permitted? is falsy for lying not allowed IPs via allowed proxies" do
       req = request("http://example.com", "REMOTE_ADDR" => "127.0.0.1", "HTTP_X_FORWARDED_FOR" => "10.0.0.0, 127.0.0.0")
 
       assert_not req.permitted?
     end
 
-    test "#permitted? is falsy for whitelisted IPs via blacklisted proxies" do
+    test "#permitted? is falsy for allowed IPs via not allowed proxies" do
       req = request("http://example.com", "REMOTE_ADDR" => "10.0.0.0", "HTTP_X_FORWARDED_FOR" => "127.0.0.0")
 
       assert_not req.permitted?


### PR DESCRIPTION
This PR updates references of old term. Deprecate the old usage.

After this PR, we can update [debugging rails guide‘s web_console setting](https://github.com/rails/rails/blob/master/guides/source/debugging_rails_applications.md#settings-1).