### PR TITLE
Add CSP nonce to injected scripts and styles

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -257,6 +257,8 @@ var promptBoxHtml = <%= render_inlined_string '_prompt_box_markup.html' %>;
 var consoleStyleCss = <%= render_inlined_string 'style.css' %>;
 // Insert a style element with the unique ID
 var styleElementId = 'sr02459pvbvrmhco';
+// Nonce to use for CSP
+var styleElementNonce = '<%= @nonce %>';
 
 // REPLConsole Constructor
 function REPLConsole(config) {
@@ -441,6 +443,9 @@ REPLConsole.prototype.insertCss = function() {
   style.type = 'text/css';
   style.innerHTML = consoleStyleCss;
   style.id = styleElementId;
+  if (styleElementNonce.length > 0) {
+    style.nonce = styleElementNonce;
+  }
   document.getElementsByTagName('head')[0].appendChild(style);
 };
 

--- a/lib/web_console/templates/layouts/javascript.erb
+++ b/lib/web_console/templates/layouts/javascript.erb
@@ -1,4 +1,4 @@
-<script type="text/javascript" data-template="<%= @template %>">
+<script type="text/javascript" data-template="<%= @template %>" nonce="<%= @nonce %>">
 (function() {
   <%= yield %>
 }).call(this);

--- a/lib/web_console/view.rb
+++ b/lib/web_console/view.rb
@@ -22,6 +22,7 @@ module WebConsole
     # leaking globals, unless you explicitly want to.
     def render_javascript(template)
       assign(template: template)
+      assign(nonce: @env["action_dispatch.content_security_policy_nonce"])
       render(template: template, layout: "layouts/javascript")
     end
 


### PR DESCRIPTION
As raised in #242, the current implementation fails if using a strict CSP. This allows the nonce generated by Rails 6+ to be added to the scripts and styles inserted into the DOM, and should be a non-breaking change.

Resolves #242.