### PR TITLE
Use MutationObserver instead of Mutation Events

### DIFF
--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -416,6 +416,14 @@ REPLConsole.prototype.install = function(container) {
     }
   }
 
+  var observer = new MutationObserver(function(mutationsList) {
+    for (let mutation of mutationsList) {
+      if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+        shiftConsoleActions();
+      }
+    }
+  });
+
   // Initialize
   this.container = container;
   this.outer = consoleOuter;
@@ -427,7 +435,7 @@ REPLConsole.prototype.install = function(container) {
 
   findChild(container, 'resizer').addEventListener('mousedown', resizeContainer);
   findChild(consoleActions, 'close-button').addEventListener('click', closeContainer);
-  consoleOuter.addEventListener('DOMNodeInserted', shiftConsoleActions);
+  observer.observe(consoleOuter, { childList: true, subtree: true });
 
   REPLConsole.currentSession = this;
 };


### PR DESCRIPTION
As raised in #288, Mutation Events have been deprecated in favour of MutationObserver, causing deprecation warnings to be shown in the Firefox dev console.

This PR refactors the current implementation to use MutationObserver instead, and preserves the existing functionality.

Resolves #288.