### PR TITLE
Fix scrolling in web console terminal

### DIFF
--- a/lib/web_console/templates/style.css.erb
+++ b/lib/web_console/templates/style.css.erb
@@ -49,7 +49,7 @@
   font-size: 11px;
   width: 100%;
   height: 100%;
-  overflow: none;
+  overflow: auto;
   background: #333;
 }
 


### PR DESCRIPTION
By default the terminal fits only 8 lines of text and scrolling is not possible. 

<img width="1048" alt="Screen Shot 2020-11-01 at 05 45 28" src="https://user-images.githubusercontent.com/964740/97793460-9aa74600-1c05-11eb-8da1-1f93d2024d0d.png">

This problem is caused by invalid ([reference](https://www.w3schools.com/cssref/pr_pos_overflow.asp) at w3schools.com) css rule (see line 52).

https://github.com/rails/web-console/blob/eeaf8473d9706999b11b381a0637574f3e603b9d/lib/web_console/templates/style.css.erb#L47-L52

Assigning `auto` fixes the issue.
The issue presents in latest Safari, Firefox, Chrome and I tested the fix in each of them.
