### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-
+arch:
+  - amd64
+  - ppc64le
 rvm:
   - 2.5.3
   - 2.6.1
@@ -24,6 +26,18 @@ matrix:
     - rvm: jruby-head
     - rvm: jruby-9.2.0.0
     - env: TEST_SUITE=templates:test
+# ppc64le support code
+    - rvm: ruby-head
+      arch: ppc64le
+    - rvm: jruby-head
+      arch: ppc64le
+    - rvm: jruby-9.2.0.0
+      arch: ppc64le
+    - env: TEST_SUITE=templates:test
+      arch: ppc64le
   include:
     - env: TEST_SUITE=templates:test
+      rvm: 2.6.1
+    - env: TEST_SUITE=templates:test
+      arch: ppc64le
       rvm: 2.6.1


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/web-console/builds/209578394