### PR TITLE
Ruby 3 compat

### DIFF
--- a/lib/web_console/evaluator.rb
+++ b/lib/web_console/evaluator.rb
@@ -19,7 +19,14 @@ module WebConsole
     end
 
     def eval(input)
-      "=> #{@binding.eval(input).inspect}\n"
+      # Binding#source_location is available since Ruby 2.6. But if this should
+      # be removed the `WebConsole::SessionTest#test_use_first_binding_if_no_application_bindings`
+      # must be adjusted.
+      if @binding.respond_to? :source_location
+        "=> #{@binding.eval(input, *@binding.source_location).inspect}\n"
+      else
+        "=> #{@binding.eval(input).inspect}\n"
+      end
     rescue Exception => exc
       format_exception(exc)
     end

--- a/lib/web_console/evaluator.rb
+++ b/lib/web_console/evaluator.rb
@@ -19,9 +19,7 @@ module WebConsole
     end
 
     def eval(input)
-      # Binding#source_location is available since Ruby 2.6. But if this should
-      # be removed the `WebConsole::SessionTest#test_use_first_binding_if_no_application_bindings`
-      # must be adjusted.
+      # Binding#source_location is available since Ruby 2.6.
       if @binding.respond_to? :source_location
         "=> #{@binding.eval(input, *@binding.source_location).inspect}\n"
       else

--- a/test/web_console/session_test.rb
+++ b/test/web_console/session_test.rb
@@ -51,6 +51,9 @@ module WebConsole
           end
         end
 
+        def source_location
+        end
+
         self
       end
 


### PR DESCRIPTION
This should fix #301.

I have split the PR into two commits. I think the first is essential while the second is NTH.

Also note that there are already similar Ruby 2.6+ condition:

https://github.com/rails/web-console/blob/167c2402aed90f4b4934b04a3ef2ed14034e9f1c/lib/web_console/source_location.rb#L8

therefore maybe `RUBY_VERSION` should be used instead of `respond_to?`