### PR TITLE
Use on_load callback for ActionDispatch::DebugExceptions

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#310](https://github.com/rails/web-console/pull/310) Use on_load callback for ActionDispatch::DebugExceptions ([@p8])
+
 ## 4.1.0
 
 * [#304](https://github.com/rails/web-console/pull/304) Add support for Rails 6.1 ([@stephannv])

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -10,7 +10,9 @@ module WebConsole
       require "bindex"
       require "web_console/extensions"
 
-      ActionDispatch::DebugExceptions.register_interceptor(Interceptor)
+      ActiveSupport.on_load(:action_dispatch_request) do
+        ActionDispatch::DebugExceptions.register_interceptor(Interceptor)
+      end
     end
 
     initializer "web_console.development_only" do
@@ -32,7 +34,9 @@ module WebConsole
     end
 
     initializer "web_console.insert_middleware" do |app|
-      app.middleware.insert_before ActionDispatch::DebugExceptions, Middleware
+      ActiveSupport.on_load(:action_dispatch_request) do
+        app.middleware.insert_before ActionDispatch::DebugExceptions, Middleware
+      end
     end
 
     initializer "web_console.mount_point" do


### PR DESCRIPTION
ActionDispatch::DebugExceptions is only available after
ActionDispatch::Request has loaded.

Fixes: https://github.com/rails/rails/issues/42801