### PR TITLE
Fix `rake templates:test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 Gemfile.lock
 node_modules/
+package-lock.json
 dist/
 tmp/

--- a/extensions/chrome/js/background.js
+++ b/extensions/chrome/js/background.js
@@ -84,10 +84,10 @@ function initHttpListener() {
   function onResponse(details) {
     var headers = getHeaders(details);
     var sessionId;
-    if (sessionId = headers['X-Web-Console-Session-Id']) {
+    if (sessionId = headers['x-web-console-session-id']) {
       sessions[details.tabId] = {
         sessionId: sessionId,
-        mountPoint: headers['X-Web-Console-Mount-Point'],
+        mountPoint: headers['x-web-console-mount-point'],
         remoteHost: details.url.match(/([^:]+:\/\/[^\/]+)\/?/)[1]
       };
     }

--- a/lib/web_console.rb
+++ b/lib/web_console.rb
@@ -26,7 +26,7 @@ module WebConsole
   end
 
   def self.logger
-    Rails.logger || (@logger ||= ActiveSupport::Logger.new($stderr))
+    (defined?(Rails.logger) && Rails.logger) || (@logger ||= ActiveSupport::Logger.new($stderr))
   end
 end
 

--- a/lib/web_console/injector.rb
+++ b/lib/web_console/injector.rb
@@ -13,10 +13,10 @@ module WebConsole
     end
 
     def inject(content)
-      # Set Content-Length header to the size of the current body
+      # Set content-length header to the size of the current body
       # + the extra content. Otherwise the response will be truncated.
-      if @headers["Content-Length"]
-        @headers["Content-Length"] = (@body.bytesize + content.bytesize).to_s
+      if @headers["content-length"]
+        @headers["content-length"] = (@body.bytesize + content.bytesize).to_s
       end
 
       [

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -28,8 +28,8 @@ module WebConsole
         status, headers, body = call_app(env)
 
         if (session = Session.from(Thread.current)) && acceptable_content_type?(headers)
-          headers["X-Web-Console-Session-Id"] = session.id
-          headers["X-Web-Console-Mount-Point"] = mount_point
+          headers["x-web-console-session-id"] = session.id
+          headers["x-web-console-mount-point"] = mount_point
 
           template = Template.new(env, session)
           body, headers = Injector.new(body, headers).inject(template.render("index"))
@@ -52,12 +52,12 @@ module WebConsole
     private
 
       def acceptable_content_type?(headers)
-        headers["Content-Type"].to_s.include?("html")
+        headers["content-type"].to_s.include?("html")
       end
 
       def json_response(opts = {})
         status  = opts.fetch(:status, 200)
-        headers = { "Content-Type" => "application/json; charset = utf-8" }
+        headers = { "content-type" => "application/json; charset = utf-8" }
         body    = yield.to_json
 
         [ status, headers, [ body ] ]

--- a/lib/web_console/tasks/templates.rake
+++ b/lib/web_console/tasks/templates.rake
@@ -12,7 +12,6 @@ namespace :templates do
   runner  = URI.parse("http://#{ENV['IP'] || '127.0.0.1'}:#{ENV['PORT'] || 29292}/html/test_runner.html")
   rackup  = "rackup --host #{runner.host} --port #{runner.port}"
   result  = nil
-  browser = "phantomjs"
 
   def need_to_wait?(uri)
     Net::HTTP.start(uri.host, uri.port) { |http| http.get(uri.path) }
@@ -24,15 +23,8 @@ namespace :templates do
     rackup += " -D --pid #{pid}"
   end
 
-  task npm: [ :phantomjs ] do
+  task :npm do
     Dir.chdir(workdir) { system "npm install --silent" }
-  end
-
-  task :phantomjs do
-    unless system("which #{browser} >/dev/null")
-      browser = "./node_modules/.bin/phantomjs"
-      Dir.chdir(workdir) { system("test -f #{browser} || npm install --silent phantomjs-prebuilt") }
-    end
   end
 
   task :rackup do
@@ -45,7 +37,7 @@ namespace :templates do
   end
 
   task :mocha do
-    Dir.chdir(workdir) { result = system("#{browser} ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js #{runner} dot") }
+    Dir.chdir(workdir) { result = system("npx mocha-headless-chrome -f #{runner} -r dot") }
   end
 
   task :kill do

--- a/lib/web_console/tasks/templates.rake
+++ b/lib/web_console/tasks/templates.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "net/http"
+
 namespace :templates do
   desc "Run tests for templates"
   task test: [ :daemonize, :npm, :rackup, :wait, :mocha, :kill, :exit ]

--- a/lib/web_console/templates/console.js.erb
+++ b/lib/web_console/templates/console.js.erb
@@ -935,8 +935,8 @@ REPLConsole.request = function request(method, url, params, callback) {
   var xhr = new REPLConsole.XMLHttpRequest();
 
   xhr.open(method, url, true);
-  xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-  xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+  xhr.setRequestHeader("content-type", "application/x-www-form-urlencoded");
+  xhr.setRequestHeader("x-requested-with", "XMLHttpRequest");
   xhr.send(params);
 
   xhr.onreadystatechange = function() {

--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -10,7 +10,7 @@ module WebConsole
     class FakeMiddleware
       I18n.load_path.concat(Dir[Helper.gem_root.join("lib/web_console/locales/*.yml")])
 
-      DEFAULT_HEADERS = { "Content-Type" => "application/javascript" }
+      DEFAULT_HEADERS = { "content-type" => "application/javascript" }
 
       def initialize(opts)
         @headers        = opts.fetch(:headers, DEFAULT_HEADERS)

--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -29,7 +29,7 @@ module WebConsole
 
         # extract target path from REQUEST_PATH
         def req_path(env)
-          env["REQUEST_PATH"].match(@req_path_regex)[1]
+          File.basename(env["REQUEST_PATH"].match(@req_path_regex)[1], ".*")
         end
 
         def render(template)

--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -22,7 +22,7 @@ module WebConsole
       end
 
       def view
-        @view = View.new(@view_path)
+        @view = View.with_empty_template_cache.with_view_paths(@view_path)
       end
 
       private

--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -19,7 +19,10 @@ module WebConsole
       end
 
       def call(env)
-        [ 200, @headers, [ render(req_path(env)) ] ]
+        body = render(req_path(env))
+        @headers["content-length"] = body.bytesize.to_s
+
+        [ 200, @headers, [ body ] ]
       end
 
       def view

--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_view"
+require "action_dispatch" # This is needed to use Mime::Type
 require "web_console"
 require "web_console/testing/helper"
 

--- a/test/templates/config.ru
+++ b/test/templates/config.ru
@@ -15,7 +15,7 @@ end
 map "/html" do
   run WebConsole::Testing::FakeMiddleware.new(
     req_path_regex: %r{^/html/(.*)},
-    headers: {"Content-Type" => "text/html"},
+    headers: {"content-type" => "text/html"},
     view_path: TEST_ROOT.join("html"),
   )
 end
@@ -42,19 +42,19 @@ map "/templates" do
 end
 
 map "/mock/repl_sessions/result" do
-  headers = { 'Content-Type' => 'application/json' }
+  headers = { 'content-type' => 'application/json' }
   body = [ { output: '=> "fake-result"\n', context: [ [ :something, :somewhat, :somewhere ] ] }.to_json ]
   run lambda { |env| [ 200, headers, body ] }
 end
 
 map "/mock/repl_sessions/error" do
-  headers = { 'Content-Type' => 'application/json' }
+  headers = { 'content-type' => 'application/json' }
   body = [ { output: 'fake-error-message' }.to_json ]
   run lambda { |env| [ 400, headers, body ] }
 end
 
 map "/mock/repl_sessions/error.txt" do
-  headers = { 'Content-Type' => 'plain/text' }
+  headers = { 'content-type' => 'plain/text' }
   body = [ 'error message' ]
   run lambda { |env| [ 400, headers, body ] }
 end

--- a/test/templates/config.ru
+++ b/test/templates/config.ru
@@ -20,13 +20,6 @@ map "/html" do
   )
 end
 
-map "/spec" do
-  run WebConsole::Testing::FakeMiddleware.new(
-    req_path_regex: %r{^/spec/(.*)},
-    view_path: TEST_ROOT.join("spec"),
-  )
-end
-
 map "/test" do
   run WebConsole::Testing::FakeMiddleware.new(
     req_path_regex: %r{^/test/(.*)},

--- a/test/templates/html/test_runner.html.erb
+++ b/test/templates/html/test_runner.html.erb
@@ -12,7 +12,6 @@
     <script src="/node_modules/chai/chai.js"></script>
     <script>
       mocha.setup('tdd');
-      mocha.reporter('html');
     </script>
 
     <!-- load templates -->

--- a/test/templates/html/test_runner.html.erb
+++ b/test/templates/html/test_runner.html.erb
@@ -26,11 +26,7 @@
 
     <!-- run tests -->
     <script>
-      if (window.mochaPhantomJS) {
-        mochaPhantomJS.run();
-      } else {
-        mocha.run();
-      }
+      mocha.run();
     </script>
   </body>
 </html>

--- a/test/templates/package.json
+++ b/test/templates/package.json
@@ -8,6 +8,6 @@
   "devDependencies": {
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
-    "mocha-phantomjs-core": "^1.3.1"
+    "mocha-headless-chrome": "^4.0.0"
   }
 }

--- a/test/templates/package.json
+++ b/test/templates/package.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/rails/web-console"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
-    "mocha": "^2.2.5",
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0",
     "mocha-phantomjs-core": "^1.3.1"
   }
 }

--- a/test/templates/test/repl_console_test.js
+++ b/test/templates/test/repl_console_test.js
@@ -179,13 +179,14 @@ suite('REPLConsole', function() {
       }, 100);
     });
 
-    test('inserts the current word if tab key is pressed', function() {
+    test('inserts the current word if tab key is pressed', function(done) {
       var c = this.console;
       c.setInput('some');
 
       setTimeout(function() {
         c.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
         assert.equal('something', c._input);
+        done();
       }, 100);
     });
   });

--- a/test/templates/test/repl_console_test.js
+++ b/test/templates/test/repl_console_test.js
@@ -1,4 +1,4 @@
-suite('REPLCosnole', function() {
+suite('REPLConsole', function() {
   suiteSetup(function() {
     this.stage = document.createElement('div');
     document.body.appendChild(this.stage);
@@ -184,7 +184,7 @@ suite('REPLCosnole', function() {
       c.setInput('some');
 
       setTimeout(function() {
-        c.onKeyDown(TestHelper.KeyDown(TestHelper.KEY_TAB));
+        c.onKeyDown(TestHelper.keyDown(TestHelper.KEY_TAB));
         assert.equal('something', c._input);
       }, 100);
     });

--- a/test/web_console/exception_mapper_test.rb
+++ b/test/web_console/exception_mapper_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 module WebConsole
-  class ExcetionMapperTest < ActiveSupport::TestCase
+  class ExceptionMapperTest < ActiveSupport::TestCase
     test "#first tries to find the first application binding" do
       Rails.stubs(:root).returns Pathname(__FILE__).parent
 

--- a/test/web_console/helper_test.rb
+++ b/test/web_console/helper_test.rb
@@ -20,7 +20,7 @@ module WebConsole
         end
 
         def headers
-          { "Content-Type" => "text/html; charset=utf-8" }
+          { "content-type" => "text/html; charset=utf-8" }
         end
 
         def body

--- a/test/web_console/injector_test.rb
+++ b/test/web_console/injector_test.rb
@@ -28,11 +28,11 @@ module WebConsole
       assert_equal [ [ "foobar" ], {} ], Injector.new(body, {}).inject("bar")
     end
 
-    test "updates the Content-Length header" do
+    test "updates the content-length header" do
       body = [ "foo" ]
-      headers = { "Content-Length" => 3 }
+      headers = { "content-length" => 3 }
 
-      assert_equal [ [ "foobar" ], { "Content-Length" => "6" } ], Injector.new(body, headers).inject("bar")
+      assert_equal [ [ "foobar" ], { "content-length" => "6" } ], Injector.new(body, headers).inject("bar")
     end
   end
 end

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -35,8 +35,8 @@ module WebConsole
 
         def headers
           Hash.new.tap do |header_hash|
-            header_hash["Content-Type"] = "#{@response_content_type}; charset=utf-8" unless @response_content_type.nil?
-            header_hash["Content-Length"] = @response_content_length unless @response_content_length.nil?
+            header_hash["content-type"] = "#{@response_content_type}; charset=utf-8" unless @response_content_type.nil?
+            header_hash["content-length"] = @response_content_length unless @response_content_length.nil?
           end
         end
     end
@@ -84,13 +84,13 @@ module WebConsole
       assert_select "#console"
     end
 
-    test "sets correct Content-Length header" do
+    test "sets correct content-length header" do
       Thread.current[:__web_console_binding] = binding
       @app = Middleware.new(Application.new(response_content_length: 7))
 
       get "/", params: nil
 
-      assert_equal(response.body.size, response.headers["Content-Length"].to_i)
+      assert_equal(response.body.size, response.headers["content-length"].to_i)
     end
 
     test "it closes original body if rendering console" do
@@ -121,12 +121,12 @@ module WebConsole
       assert_select "#console", 0
     end
 
-    test "returns X-Web-Console-Session-Id as response header" do
+    test "returns x-web-console-session-id as response header" do
       Thread.current[:__web_console_binding] = binding
 
       get "/", params: nil
 
-      session_id = response.headers["X-Web-Console-Session-Id"]
+      session_id = response.headers["x-web-console-session-id"]
 
       assert_not Session.find(session_id).nil?
     end


### PR DESCRIPTION
`rake templates:test` was left to fail for a long time.
This PR will fix it (with a slightly larger number of file changes).
Here are the details:

- Fix for the edge Rails
  - Address the change of ActionView::Base.new in Rails 6 
    - Same change as #304
  - Render templates without `.` in the name 
    - Similar change as #298
    - refs:
      - rails/rails#39164
      - https://stackoverflow.com/questions/68836670/rails-6-1-4-deprecation-warning-rendering-actions-with
  - Check `Rails.logger` is defined 
    - ActionView is in use without Rails at `rake templates:test`
  - `require "action_dispatch"` to use `Mime::Type` 
    - This fixes the following error:
      ```
      ActionView::Template::Error: undefined method `to_sym' for nil:NilClass

                @symbol = symbol.to_sym
                          ^^^^^^^
      ```
- Fix for the edge Rack
  - **Lowercase response headers**
    - The latest rack 3.0 (unreleased) does not accept uppercase headers.
      See rack/rack#1592 for more details.
    - refs:
      - rack/rack#1812
      - rails/sprockets#744
    - It required changes not only to files under `test/`, also to files under `lib/`. 
  - Set content-length header in the `FakeMiddleware`
    - Similar change as #290
- Replace mocha-phantomjs-core with mocha-headless-chrome
  - web-console has ES6 syntax codes introduced in #297 and #308.
  - phantomjs does not support ES6, so it is replaced with [mocha-headless-chrome](https://github.com/direct-adv-interfaces/mocha-headless-chrome).

I ran the test locally and confirmed that it succeeded.
```
$ bundle exec rake templates:test


..............................
30 passing (679ms)
```
