### PR TITLE
Remove extra exception wrapper allocation

### DIFF
--- a/lib/web_console/interceptor.rb
+++ b/lib/web_console/interceptor.rb
@@ -1,8 +1,7 @@
 module WebConsole
   module Interceptor
-    def self.call(request, exception)
+    def self.call(request, error)
       backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
-      error = ActionDispatch::ExceptionWrapper.new(backtrace_cleaner, exception).exception
 
       # Get the original exception if ExceptionWrapper decides to follow it.
       Thread.current[:__web_console_exception] = error


### PR DESCRIPTION
```ruby
ActionDispatch::ExceptionWrapper.new(backtrace_cleaner, exception).exception
```

The above code just returns the original exception object.  You can see [in
Rails](https://github.com/rails/rails/blob/08ef43ed5e01b42b2aec847a0424515f537ed427/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L44-L48) the exception is simply stored in an ivar and then returned with an attr_reader.  There shouldn't be any reason to construct this object