### PR TITLE
Use a dedicated ActiveSupport::Deprecation object

### DIFF
--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -51,6 +51,10 @@ module WebConsole
       end
     end
 
+    initializer "web_console.deprecator" do |app|
+      app.deprecators[:web_console] = ActiveSupport::Deprecation.new("5.0", "WebConsole")
+    end
+
     initializer "web_console.permissions" do
       permissions = web_console_permissions
       Request.permissions = Permissions.new(permissions)
@@ -63,7 +67,7 @@ module WebConsole
       when config.web_console.allowed_ips
         config.web_console.allowed_ips
       when config.web_console.whitelisted_ips
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        Rails.application.deprecators[:web_console].warn(<<-MSG.squish)
           The config.web_console.whitelisted_ips is deprecated and will be ignored in future release of web_console.
           Please use config.web_console.allowed_ips instead.
         MSG


### PR DESCRIPTION
Rails 7.1 will deprecate usage of the ActiveSupport::Deprecation singleton (calling warn, silence, etc. directly on it) (see https://github.com/rails/rails/pull/47354).

Unlike other PRs like https://github.com/rails/sprockets-rails/pull/517 I didn't create a `WebConsole.deprecator` since it was only used in one spot. Let me know if you'd rather have that.