### PR TITLE
[FIX #331] Add simultaneous support for Rack 2 and 3

### DIFF
--- a/lib/web_console/injector.rb
+++ b/lib/web_console/injector.rb
@@ -15,8 +15,8 @@ module WebConsole
     def inject(content)
       # Set content-length header to the size of the current body
       # + the extra content. Otherwise the response will be truncated.
-      if @headers["content-length"]
-        @headers["content-length"] = (@body.bytesize + content.bytesize).to_s
+      if @headers[Rack::CONTENT_LENGTH]
+        @headers[Rack::CONTENT_LENGTH] = (@body.bytesize + content.bytesize).to_s
       end
 
       [

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -52,12 +52,12 @@ module WebConsole
     private
 
       def acceptable_content_type?(headers)
-        headers["content-type"].to_s.include?("html")
+        headers[Rack::CONTENT_TYPE].to_s.include?("html")
       end
 
       def json_response(opts = {})
         status  = opts.fetch(:status, 200)
-        headers = { "content-type" => "application/json; charset = utf-8" }
+        headers = { Rack::CONTENT_TYPE => "application/json; charset = utf-8" }
         body    = yield.to_json
 
         [ status, headers, [ body ] ]

--- a/lib/web_console/testing/fake_middleware.rb
+++ b/lib/web_console/testing/fake_middleware.rb
@@ -10,7 +10,7 @@ module WebConsole
     class FakeMiddleware
       I18n.load_path.concat(Dir[Helper.gem_root.join("lib/web_console/locales/*.yml")])
 
-      DEFAULT_HEADERS = { "content-type" => "application/javascript" }
+      DEFAULT_HEADERS = { Rack::CONTENT_TYPE => "application/javascript" }
 
       def initialize(opts)
         @headers        = opts.fetch(:headers, DEFAULT_HEADERS)
@@ -20,7 +20,7 @@ module WebConsole
 
       def call(env)
         body = render(req_path(env))
-        @headers["content-length"] = body.bytesize.to_s
+        @headers[Rack::CONTENT_LENGTH] = body.bytesize.to_s
 
         [ 200, @headers, [ body ] ]
       end

--- a/test/templates/config.ru
+++ b/test/templates/config.ru
@@ -15,7 +15,7 @@ end
 map "/html" do
   run WebConsole::Testing::FakeMiddleware.new(
     req_path_regex: %r{^/html/(.*)},
-    headers: {"content-type" => "text/html"},
+    headers: {Rack::CONTENT_TYPE => "text/html"},
     view_path: TEST_ROOT.join("html"),
   )
 end
@@ -35,19 +35,19 @@ map "/templates" do
 end
 
 map "/mock/repl_sessions/result" do
-  headers = { 'content-type' => 'application/json' }
+  headers = { Rack::CONTENT_TYPE => 'application/json' }
   body = [ { output: '=> "fake-result"\n', context: [ [ :something, :somewhat, :somewhere ] ] }.to_json ]
   run lambda { |env| [ 200, headers, body ] }
 end
 
 map "/mock/repl_sessions/error" do
-  headers = { 'content-type' => 'application/json' }
+  headers = { Rack::CONTENT_TYPE => 'application/json' }
   body = [ { output: 'fake-error-message' }.to_json ]
   run lambda { |env| [ 400, headers, body ] }
 end
 
 map "/mock/repl_sessions/error.txt" do
-  headers = { 'content-type' => 'plain/text' }
+  headers = { Rack::CONTENT_TYPE => 'plain/text' }
   body = [ 'error message' ]
   run lambda { |env| [ 400, headers, body ] }
 end

--- a/test/web_console/helper_test.rb
+++ b/test/web_console/helper_test.rb
@@ -20,7 +20,7 @@ module WebConsole
         end
 
         def headers
-          { "content-type" => "text/html; charset=utf-8" }
+          { Rack::CONTENT_TYPE => "text/html; charset=utf-8" }
         end
 
         def body

--- a/test/web_console/injector_test.rb
+++ b/test/web_console/injector_test.rb
@@ -30,9 +30,9 @@ module WebConsole
 
     test "updates the content-length header" do
       body = [ "foo" ]
-      headers = { "content-length" => 3 }
+      headers = { Rack::CONTENT_LENGTH => 3 }
 
-      assert_equal [ [ "foobar" ], { "content-length" => "6" } ], Injector.new(body, headers).inject("bar")
+      assert_equal [ [ "foobar" ], { Rack::CONTENT_LENGTH => "6" } ], Injector.new(body, headers).inject("bar")
     end
   end
 end

--- a/test/web_console/middleware_test.rb
+++ b/test/web_console/middleware_test.rb
@@ -35,8 +35,8 @@ module WebConsole
 
         def headers
           Hash.new.tap do |header_hash|
-            header_hash["content-type"] = "#{@response_content_type}; charset=utf-8" unless @response_content_type.nil?
-            header_hash["content-length"] = @response_content_length unless @response_content_length.nil?
+            header_hash[Rack::CONTENT_TYPE] = "#{@response_content_type}; charset=utf-8" unless @response_content_type.nil?
+            header_hash[Rack::CONTENT_LENGTH] = @response_content_length unless @response_content_length.nil?
           end
         end
     end
@@ -90,7 +90,7 @@ module WebConsole
 
       get "/", params: nil
 
-      assert_equal(response.body.size, response.headers["content-length"].to_i)
+      assert_equal(response.body.size, response.headers[Rack::CONTENT_LENGTH].to_i)
     end
 
     test "it closes original body if rendering console" do


### PR DESCRIPTION
# Context
#318 introduced a  regression (#331) for apps running Rack 2. 
Rack 3 follows the HTTP 2 spec and requires lower case headers. 

By using the Rack header constants we get the correct capitalization regardless of which rack version is loaded.

# Considerations

- I decided to use the rack constants directly. If lower coupling to rack is desired I can edit the PR to add a constant file instead.
- CI tests both Rack 2 and Rack 3, but didn't raise a failure. There is probably a gap in the test suite. 