### PR TITLE
Permissions are not working when runs thru ngrok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 package-lock.json
 dist/
 tmp/
+.idea/

--- a/README.markdown
+++ b/README.markdown
@@ -87,6 +87,14 @@ end
 Take a note that IPv4 and IPv6 localhosts are always allowed. This wasn't the
 case in 2.0.
 
+Allow any network address to access the console:
+
+```ruby
+Rails.application.configure do
+  config.web_console.allow_from_all = true
+end
+```
+
 ### config.web_console.whiny_requests
 
 When a console cannot be shown for a given IP address or content type,

--- a/lib/web_console/middleware.rb
+++ b/lib/web_console/middleware.rb
@@ -8,6 +8,7 @@ module WebConsole
 
     cattr_accessor :mount_point, default: "/__web_console"
     cattr_accessor :whiny_requests, default: true
+    cattr_accessor :allow_all_connections_from_any_ip, default: false
 
     def initialize(app)
       @app = app
@@ -16,7 +17,7 @@ module WebConsole
     def call(env)
       app_exception = catch :app_exception do
         request = create_regular_or_whiny_request(env)
-        return call_app(env) unless request.permitted?
+        return call_app(env) unless request.permitted?(allow_all_connections_from_any_ip)
 
         if id = id_for_repl_session_update(request)
           return update_repl_session(id, request)

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -60,6 +60,10 @@ module WebConsole
       Request.permissions = Permissions.new(permissions)
     end
 
+    initializer "web_console.allow_from_all" do
+      Middleware.allow_all_connections_from_any_ip = true if config.web_console.allow_from_all
+    end
+
     def web_console_permissions
       case
       when config.web_console.permissions

--- a/lib/web_console/request.rb
+++ b/lib/web_console/request.rb
@@ -4,8 +4,8 @@ module WebConsole
   class Request < ActionDispatch::Request
     cattr_accessor :permissions, default: Permissions.new
 
-    def permitted?
-      permissions.include?(strict_remote_ip)
+    def permitted?(allow_all_connections_from_any_ip = false)
+      permissions.include?(strict_remote_ip) || allow_all_connections_from_any_ip
     end
 
     def strict_remote_ip

--- a/lib/web_console/whiny_request.rb
+++ b/lib/web_console/whiny_request.rb
@@ -6,8 +6,8 @@ module WebConsole
   # If any calls to +permitted?+ and +acceptable_content_type?+
   # return false, an info log message will be displayed in users' logs.
   class WhinyRequest < SimpleDelegator
-    def permitted?
-      whine_unless request.permitted? do
+    def permitted?(allow_all_connections_from_any_ip = false)
+      whine_unless(request.permitted?(allow_all_connections_from_any_ip))  do
         "Cannot render console from #{request.strict_remote_ip}! " \
           "Allowed networks: #{request.permissions}"
       end


### PR DESCRIPTION
Resolves https://github.com/rails/web-console/issues/333

### Feature: 

Add the ability for the app to allow any IP to open the console.

### How: 

Add to application file:

```ruby
config.web_console.allow_from_all = true
```