### PR TITLE
add the ability to store last eval in variable.

### DIFF
--- a/lib/web_console/evaluator.rb
+++ b/lib/web_console/evaluator.rb
@@ -7,12 +7,15 @@ module WebConsole
   # difference of a regular +Binding+ eval is that +Evaluator+ will always
   # return a string and will format exception output.
   class Evaluator
+    # stores last evalutation in this variable for futher use.
+    cattr_accessor :last_evaluation_variable, default: '_'
     # Cleanses exceptions raised inside #eval.
     cattr_reader :cleaner, default: begin
       cleaner = ActiveSupport::BacktraceCleaner.new
       cleaner.add_silencer { |line| line.start_with?(File.expand_path("..", __FILE__)) }
       cleaner
     end
+
 
     def initialize(binding = TOPLEVEL_BINDING)
       @binding = binding
@@ -21,15 +24,22 @@ module WebConsole
     def eval(input)
       # Binding#source_location is available since Ruby 2.6.
       if @binding.respond_to? :source_location
-        "=> #{@binding.eval(input, *@binding.source_location).inspect}\n"
+        output = "=> #{@binding.eval(input, *@binding.source_location).inspect}\n"
       else
-        "=> #{@binding.eval(input).inspect}\n"
+        output = "=> #{@binding.eval(input).inspect}\n"
       end
+      set_last_eval(input)
+      output
     rescue Exception => exc
       format_exception(exc)
     end
 
     private
+
+      def set_last_eval(input)
+        return if input.blank?
+        @binding.eval("#{last_evaluation_variable} = #{input}")
+      end
 
       def format_exception(exc)
         backtrace = cleaner.clean(Array(exc.backtrace) - caller)

--- a/lib/web_console/railtie.rb
+++ b/lib/web_console/railtie.rb
@@ -84,5 +84,11 @@ module WebConsole
     initializer "i18n.load_path" do
       config.i18n.load_path.concat(Dir[File.expand_path("../locales/*.yml", __FILE__)])
     end
+
+    initializer 'web_console.last_evaluation_variable' do
+      if last_evaluation_variable = config.web_console.last_evaluation_variable
+        Evaluator.last_evaluation_variable = last_evaluation_variable
+      end
+    end
   end
 end

--- a/test/web_console/evaluator_test.rb
+++ b/test/web_console/evaluator_test.rb
@@ -66,6 +66,22 @@ module WebConsole
       END
     end
 
+    test "Evaluator preserve the last value in the _ variable" do
+      @repl.class.last_evaluation_variable = "_"
+      assert_equal "=> 42\n", @repl.eval("foo = 42")
+      assert_equal "=> 42\n", @repl.eval("_")
+      assert_equal "=> 50\n", @repl.eval("_ + 8")
+      assert_equal "=> 50\n", @repl.eval("_")
+    end
+
+    test "last evaluation variable can be configured" do
+      assert_equal "=> 42\n", @repl.eval("foo = 42")
+      assert_equal "=> 42\n", @repl.eval("_")
+      @repl.class.last_evaluation_variable = "$_last_value"
+      assert_equal "=> 42\n", @repl.eval("foo = 42")
+      assert_equal "=> 42\n", @repl.eval("$_last_value")
+    end
+
     private
 
       def current_trace


### PR DESCRIPTION
Add the ability to store the last eval in a variable configured through the web_console.config, default is _ 

I always found it a bit annoying that when working with the web_console, I always forget to store in a variable whatever I'm trying, so if it is what I expect, keep working on that return for more trying/error, especially when working with complicated queries or trying out a mutation in an array or something along that lines. Where you get the desired value, but it is lost as it is not stored anywhere.

I have plans to work in the UI as I have some ideas I would like to see if they make sense to implement.
There is a lot of code around to make development a bit easier, but I'm unsure how to make it work/setup. Some docs about it will help people work more in this gem.


https://github.com/rails/web-console/assets/24831929/8d8b34d8-bb7d-4285-a8d3-7ea60b896e5b

