### PR TITLE
Drop unused dependency on `activemodel`

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -2,7 +2,6 @@
 
 require File.expand_path("../boot", __FILE__)
 
-require "active_model/railtie"
 require "action_controller/railtie"
 require "action_view/railtie"
 

--- a/web-console.gemspec
+++ b/web-console.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   rails_version = ">= 6.0.0"
 
   s.add_dependency "railties",    rails_version
-  s.add_dependency "activemodel", rails_version
   s.add_dependency "actionview",  rails_version
   s.add_dependency "bindex",      ">= 0.4.0"
 end


### PR DESCRIPTION
This drops the dependency on `activemodel`, as it stopped being used back in #94.