### PR TITLE
Always permit IPv4-mapped IPv6 loopback addresses

### DIFF
--- a/lib/web_console/permissions.rb
+++ b/lib/web_console/permissions.rb
@@ -5,7 +5,7 @@ require "ipaddr"
 module WebConsole
   class Permissions
     # IPv4 and IPv6 localhost should be always allowed.
-    ALWAYS_PERMITTED_NETWORKS = %w( 127.0.0.0/8 ::1 )
+    ALWAYS_PERMITTED_NETWORKS = %w( 127.0.0.0/8 ::1 ::ffff:127.0.0.0/104 )
 
     def initialize(networks = nil)
       @networks = normalize_networks(networks).map(&method(:coerce_network_to_ipaddr)).uniq

--- a/test/web_console/permissions_test.rb
+++ b/test/web_console/permissions_test.rb
@@ -9,6 +9,7 @@ module WebConsole
 
       assert_includes permissions, "127.0.0.1"
       assert_includes permissions, "::1"
+      assert_includes permissions, "::ffff:127.0.0.1"
     end
 
     test "permits single IPs" do
@@ -41,7 +42,7 @@ module WebConsole
     end
 
     test "human readable presentation" do
-      assert_includes permit.to_s, "127.0.0.0/127.255.255.255, ::1"
+      assert_includes permit.to_s, "127.0.0.0/127.255.255.255, ::1, ::ffff:127.0.0.0/::ffff:127.255.255.255"
     end
 
     private


### PR DESCRIPTION
When the server, e.g., Puma binds to unspecified IPv6 address `[::]` with ,e.g.,:
```ruby, config/puma.rb
port ENV.fetch("PORT", 3000), "::"
```
the server sees the local client connecting from an IPv4-mapped address `::ffff:127.0.0.1`. This makes connection to the web console rejected with:
```
Cannot render console from ::ffff:127.0.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
```
unless loopback addresses expressed as IPv4-mapped addressses are premitted.